### PR TITLE
Add higher kinded polymorphism

### DIFF
--- a/src/Pukeko/Error.hs
+++ b/src/Pukeko/Error.hs
@@ -10,6 +10,7 @@ module Pukeko.Error
   , runExcept
   , ExceptT (..)
   , runExceptT
+  , here
   )
   where
 
@@ -45,3 +46,6 @@ runExcept = either throwError return . Except.runExcept
 
 runExceptT :: (MonadError e m, Monad n) => ExceptT e n a -> n (m a)
 runExceptT = fmap (either throwError return) . Except.runExceptT
+
+here :: MonadError String m => Pos -> m a -> m a
+here pos act = act `catchError` throwErrorAt pos

--- a/src/Pukeko/Language/KindChecker.hs
+++ b/src/Pukeko/Language/KindChecker.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 -- | Check that all type constructor are applied to the right number of
 -- variables and all variables are bound.
 module Pukeko.Language.KindChecker
@@ -6,56 +7,200 @@ module Pukeko.Language.KindChecker
   )
 where
 
-import           Control.Monad (unless)
+import           Control.Lens
+import           Control.Monad.Reader
+import           Control.Monad.State
+import           Control.Monad.ST
 import           Data.Foldable
-import           Data.Maybe    (catMaybes)
-import qualified Data.Set      as Set
+import           Data.Forget      (Forget (..))
+import           Data.Maybe       (catMaybes)
+import qualified Data.Map         as Map
+import           Data.STRef
+import           Data.Traversable
 
 import           Pukeko.Error
 import           Pukeko.Pretty
-import           Pukeko.Language.AST.Std
+import           Pukeko.Language.AST.Std          hiding (Free)
+import qualified Pukeko.Language.Ident            as Id
 import qualified Pukeko.Language.TypeResolver.AST as TR
 import qualified Pukeko.Language.KindChecker.AST  as KC
 import qualified Pukeko.Language.Type             as Ty
 
 type Type = Ty.Type KC.TypeCon Ty.Closed
 
-type KC a = Except String a
+data Open s
 
-kcType :: Pos -> Type -> KC ()
-kcType w = go 0
+data UVar s
+  = Free (Forget Id.TVar)
+  | Link (Kind (Open s))
+
+data Kind a where
+  Star  ::                     Kind a
+  Arrow :: Kind a -> Kind a -> Kind a
+  UVar  :: STRef s (UVar s) -> Kind (Open s)
+
+type KCEnv s = Map.Map Id.TVar (Kind (Open s))
+
+data KCState s = MkKCState
+  { _typeCons :: Map.Map Id.Con (Kind (Open s))
+  , _fresh    :: [Id.TVar]
+  }
+makeLenses ''KCState
+
+newtype KC s a =
+  KC{unKC :: ReaderT (KCEnv s) (StateT (KCState s) (ExceptT String (ST s))) a}
+  deriving ( Functor, Applicative, Monad
+           , MonadError String
+           , MonadReader (KCEnv s)
+           , MonadState (KCState s)
+           )
+
+runKC :: MonadError String m => (forall s. KC s a) -> m a
+runKC kc = runST (runExceptT (evalStateT (runReaderT (unKC kc) env) st0))
   where
-    go :: Int -> Type -> KC ()
-    go n = \case
-      Ty.Var _ | n == 0 -> pure ()
-      Ty.Arr   | n == 2 -> pure ()
-      Ty.Con Ty.MkADT{_name, _params}
-        -- TODO: Check that params are mutually distinct.
-        | length _params == n -> pure ()
-        | otherwise           ->
-            throwDocAt w $
-            "type cons" <+> quotes (pretty _name) <+> "expects" <+>
-            int (length _params) <+> "parameters"
-      Ty.App tf tp -> go (n+1) tf *> go 0 tp
-      _ -> bug "kind checker" "higher kinded polymorphism is not implemented yet" Nothing
+    st0 = MkKCState
+      { _typeCons = Map.empty
+      , _fresh    = Id.freshTVars
+      }
+    env = Map.empty
 
-kcTopLevel :: TR.TopLevel -> KC (Maybe KC.TopLevel)
+liftST :: ST s a -> KC s a
+liftST = KC . lift . lift . lift
+
+freshUVar :: KC s (Kind (Open s))
+freshUVar = do
+  v <- fresh %%= (\(v:vs) -> (v, vs))
+  UVar <$> liftST (newSTRef (Free (Forget v)))
+
+kcType :: Kind (Open s) -> Type -> KC s ()
+kcType k = \case
+  Ty.Var v -> do
+    kv_opt <- view (at v)
+    case kv_opt of
+      Nothing -> throwDoc $ "unknown type variable:" <+> pretty v
+      Just kv -> unify kv k
+  Ty.Arr -> unify (Arrow Star (Arrow Star Star)) k
+  Ty.Con Ty.MkADT{_name = con} -> do
+    kcon_opt <- use (typeCons . at con)
+    case kcon_opt of
+      Nothing -> bug "kind checker" "unknown type constructor" (Just (show con))
+      Just kcon -> unify kcon k
+  Ty.App tf tp -> do
+    ktp <- freshUVar
+    kcType ktp tp
+    kcType (Arrow ktp k) tf
+
+
+kcTypDef :: [Ty.ADT (Ty.ADT Id.Con)] -> KC s ()
+kcTypDef adts = do
+  kinds <- for adts $ \Ty.MkADT{_name} -> do
+    kind <- freshUVar
+    typeCons . at _name ?= kind
+    pure kind
+  for_ (zip adts kinds) $ \(Ty.MkADT{_params, _constructors}, adtKind) -> do
+    paramKinds <- traverse (const freshUVar) _params
+    unify adtKind (foldr Arrow Star paramKinds)
+    let env = Map.fromList (zip _params paramKinds)
+    local (const env) $ do
+      for_ _constructors $ \Ty.MkConstructor{_fields} -> do
+        traverse_ (kcType Star) _fields
+  traverse_ close kinds
+
+kcVal :: Ty.Type (Ty.ADT Id.Con) Ty.Closed ->KC s ()
+kcVal t = do
+  env <- sequence $ Map.fromSet (const freshUVar) (Ty.vars t)
+  local (const env) $ kcType Star t
+
+
+kcTopLevel :: TR.TopLevel -> KC s (Maybe KC.TopLevel)
 kcTopLevel = \case
   TR.TypDef w adts -> do
-    for_ adts $ \Ty.MkADT{_params, _constructors} -> do
-      for_ _constructors $ \Ty.MkConstructor{_name, _fields} -> do
-        let unbound =
-              Set.unions (map Ty.vars _fields) `Set.difference` Set.fromList _params
-        unless (Set.null unbound) $ throwAt w "unbound type vars in term cons" _name
-        traverse_ (kcType w) _fields
-    return Nothing
-  TR.Val    w x  t -> Just <$> KC.Val w x <$> (kcType w t *> pure t)
+    here w (kcTypDef adts)
+    pure Nothing
+  TR.Val    w x  t -> do
+    here w (kcVal t)
+    pure $ Just (KC.Val w x t)
   TR.TopLet w ds   -> pure $ Just $ KC.TopLet w (fmap retagDefn ds)
   TR.TopRec w ds   -> pure $ Just $ KC.TopRec w (fmap retagDefn ds)
   TR.Asm    w x  a -> pure $ Just $ KC.Asm w x a
 
-kcModule ::TR.Module -> KC KC.Module
+kcModule ::TR.Module -> KC s KC.Module
 kcModule module_ = catMaybes <$> traverse kcTopLevel module_
 
 checkModule :: MonadError String m => TR.Module -> m KC.Module
-checkModule = runExcept . kcModule
+checkModule module_ = runKC (kcModule module_)
+
+
+unwind :: Kind (Open s) -> KC s (Kind (Open s))
+unwind = \case
+  k0@(UVar uref) -> do
+    uvar <- liftST (readSTRef uref)
+    case uvar of
+      Free _  -> pure k0
+      Link k1 -> do
+        k2 <- unwind k1
+        liftST (writeSTRef uref (Link k2))
+        pure k2
+  k -> pure k
+
+assertFree :: STRef s (UVar s) -> KC s ()
+assertFree uref = do
+  uvar <- liftST (readSTRef uref)
+  case uvar of
+    Free _ -> pure ()
+    Link _ -> bug "kind checker" "unwinding produced link" Nothing
+
+occursCheck :: STRef s (UVar s) -> Kind (Open s) -> KC s ()
+occursCheck uref1 = \case
+  Star        -> pure ()
+  Arrow kf kp -> occursCheck uref1 kf *> occursCheck uref1 kp
+  UVar uref2
+    | uref1 == uref2 -> throwError "occurs check"
+    | otherwise -> do
+        uvar2 <- liftST (readSTRef uref2)
+        case uvar2 of
+          Link k2 -> occursCheck uref1 k2
+          Free _  -> pure ()
+
+unify :: Kind (Open s) -> Kind (Open s) -> KC s ()
+unify k1 k2 = do
+  k1 <- unwind k1
+  k2 <- unwind k2
+  case (k1, k2) of
+    (Star, Star) -> pure ()
+    (Arrow kf1 kp1, Arrow kf2 kp2) -> unify kf1 kf2 *> unify kp1 kp2
+    (UVar uref1, UVar uref2)
+      | uref1 == uref2 -> pure ()
+    (UVar uref1, _) -> do
+      assertFree uref1
+      occursCheck uref1 k2
+      liftST (writeSTRef uref1 (Link k2))
+    (_, UVar _) -> unify k2 k1
+    -- TODO: Improve error message.
+    (_, _) -> do
+      d1 <- liftST (prettyKind False k1)
+      d2 <- liftST (prettyKind False k2)
+      throwDoc $ "cannot unify kinds" <+> d1 <+> "and" <+> d2
+
+close :: Kind (Open s) -> KC s ()
+close k = do
+  k <- unwind k
+  case k of
+    Star -> pure ()
+    Arrow kf kp -> close kf *> close kp
+    UVar uref -> do
+      assertFree uref
+      liftST (writeSTRef uref (Link Star))
+
+prettyKind :: Bool -> Kind (Open s) -> ST s Doc
+prettyKind prec = \case
+  Star -> pure (text "*")
+  Arrow kf kp -> do
+    df <- prettyKind True  kf
+    dp <- prettyKind False kp
+    pure $ maybeParens prec (df <+> "->" <+> dp)
+  UVar uref -> do
+    uvar <- readSTRef uref
+    case uvar of
+      Free (Forget v) -> pure (pretty v)
+      Link k          -> prettyKind prec k

--- a/src/Pukeko/Language/Parser.hs
+++ b/src/Pukeko/Language/Parser.hs
@@ -73,13 +73,11 @@ type_, atype :: Parser (Ty.Type TypeCon Ty.Closed)
 type_ =
   buildExpressionParser
     [ [ Infix (arrow *> pure (Ty.~>)) AssocRight ] ]
-    ( Ty.appADT <$> constructor <*> many atype
-      <|> atype
-    )
+    (Ty.app <$> atype <*> many atype)
   <?> "type"
 atype = choice
   [ Ty.var <$> tvar
-  , Ty.appADT <$> constructor <*> pure []
+  , Ty.con <$> constructor
   , parens type_
   ]
 

--- a/src/Pukeko/Language/Parser.hs
+++ b/src/Pukeko/Language/Parser.hs
@@ -73,13 +73,13 @@ type_, atype :: Parser (Ty.Type TypeCon Ty.Closed)
 type_ =
   buildExpressionParser
     [ [ Infix (arrow *> pure (Ty.~>)) AssocRight ] ]
-    ( Ty.app <$> constructor <*> many atype
+    ( Ty.appADT <$> constructor <*> many atype
       <|> atype
     )
   <?> "type"
 atype = choice
   [ Ty.var <$> tvar
-  , Ty.app <$> constructor <*> pure []
+  , Ty.appADT <$> constructor <*> pure []
   , parens type_
   ]
 

--- a/src/Pukeko/Language/Type.hs
+++ b/src/Pukeko/Language/Type.hs
@@ -13,6 +13,7 @@ module Pukeko.Language.Type
   , Closed
   , open
   , var
+  , con
   , (~>)
   , (*~>)
   , app
@@ -94,6 +95,9 @@ pattern Fun tx ty = App (App Arr tx) ty
 
 var :: Ident.TVar -> Type con a
 var = Var
+
+con :: con -> Type con a
+con = Con
 
 (~>) :: Type con a -> Type con a -> Type con a
 (~>) = Fun

--- a/src/Pukeko/Language/Type.hs
+++ b/src/Pukeko/Language/Type.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE GADTs #-}
 module Pukeko.Language.Type
   ( ADT (..)
@@ -15,30 +16,26 @@ module Pukeko.Language.Type
   , (~>)
   , (*~>)
   , app
+  , appADT
   , typeInt
   , vars
   , openVars
   , openSubst
+  , type2con
   , prettyType
-
-    -- * Optics
-  , typeCons
   )
   where
 
-import Control.Lens
-import Control.Monad.Reader
-import Control.Monad.ST
-import Data.Map (Map)
-import Data.Ratio () -- for precedences in pretty printer
-import Data.Set (Set)
-import Data.STRef
+import           Control.Lens         (Traversal)
+import           Control.Monad.Reader
+import           Control.Monad.ST
+import           Data.Ratio () -- for precedences in pretty printer
+import           Data.STRef
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
-import Pukeko.Error
-import Pukeko.Pretty
-
+import           Pukeko.Error
+import           Pukeko.Pretty
 import qualified Pukeko.Language.Ident as Ident
 
 infixr 1 ~>, *~>
@@ -67,9 +64,6 @@ mkConstructor :: Ident.Con -> [Type con Closed] -> Constructor con
 mkConstructor _name _fields =
   MkConstructor { _adt = undefined, _name, _tag = undefined, _fields }
 
-adt :: con -> [Type con Closed] -> Type con Closed
-adt adt = app adt
-
 -- constructors :: ADT con -> [(Ident.Con, Type con Closed)]
 -- constructors t@MkADT{ _params, _constructors } = map f _constructors
 --   where
@@ -78,7 +72,7 @@ adt adt = app adt
 
 typeOf :: Constructor (ADT Ident.Con) -> Type (ADT Ident.Con) Closed
 typeOf MkConstructor{ _adt, _fields } =
-  foldr (~>) (adt _adt $ map var $ _params _adt) _fields
+  foldr (~>) (appADT _adt $ map var $ _params _adt) _fields
 
 
 data Open s
@@ -89,10 +83,14 @@ data UVar con s
   | Link{_type  :: Type con (Open s)}
 
 data Type con a where
-  Var  :: Ident.TVar                 -> Type con a
-  Fun  :: Type con a ->  Type con a  -> Type con a
-  App  :: con        -> [Type con a] -> Type con a
-  UVar :: STRef s (UVar con s)       -> Type con (Open s)
+  Var  :: Ident.TVar               -> Type con a
+  Arr  ::                             Type con a
+  Con  :: con                      -> Type con a
+  App  :: Type con a -> Type con a -> Type con a
+  UVar :: STRef s (UVar con s)     -> Type con (Open s)
+
+pattern Fun :: Type con a -> Type con a -> Type con a
+pattern Fun tx ty = App (App Arr tx) ty
 
 var :: Ident.TVar -> Type con a
 var = Var
@@ -103,50 +101,68 @@ var = Var
 (*~>) :: [Type con a] -> Type con a -> Type con a
 t_args *~> t_res = foldr (~>) t_res t_args
 
-app :: con -> [Type con a] -> Type con a
-app = App
+app :: Type con a -> [Type con a] -> Type con a
+app = foldl App
+
+appADT :: con -> [Type con a] -> Type con a
+appADT = app . Con
 
 -- TODO: Remove this undefined hack.
 typeInt :: Type (ADT Ident.Con) Closed
-typeInt  = app (mkADT (Ident.constructor "Int") undefined [] []) []
+typeInt  = appADT (mkADT (Ident.constructor "Int") undefined [] []) []
 
 open :: Type con Closed -> Type con (Open s)
-open t = case t of
+open = \case
   Var name  -> Var name
-  Fun tx ty -> Fun (open tx) (open ty)
-  App c  ts -> App c (map open ts)
+  Arr       -> Arr
+  Con c     -> Con c
+  App tf tp -> App (open tf) (open tp)
 
-vars :: Type con Closed -> Set Ident.TVar
+vars :: Type con Closed -> Set.Set Ident.TVar
 vars t = runST $ openVars (open t)
 
-openVars :: Type con (Open s) -> ST s (Set Ident.TVar)
-openVars t = case t of
-  Var v -> return $ Set.singleton v
-  Fun tx ty -> Set.union <$> openVars tx <*> openVars ty
-  App _  ts -> Set.unions <$> traverse openVars ts
+openVars :: Type con (Open s) -> ST s (Set.Set Ident.TVar)
+openVars = \case
+  Var v -> pure (Set.singleton v)
+  Arr   -> pure Set.empty
+  Con _ -> pure Set.empty
+  App tf tp -> Set.union <$> openVars tf <*> openVars tp
   UVar uref -> do
     uvar <- readSTRef uref
     case uvar of
-      Free{} -> return $ Set.empty
+      Free{}      -> pure Set.empty
       Link{_type} -> openVars _type
 
-openSubst :: Map Ident.TVar (Type con (Open s)) -> Type con (Open s) -> ST s (Type con (Open s))
+openSubst :: Map.Map Ident.TVar (Type con (Open s)) -> Type con (Open s) -> ST s (Type con (Open s))
 openSubst env t = runReaderT (subst' t) env
   where
     subst' :: Type con (Open s)
-           -> ReaderT (Map Ident.TVar (Type con (Open s))) (ST s) (Type con (Open s))
-    subst' t = case t of
+           -> ReaderT (Map.Map Ident.TVar (Type con (Open s))) (ST s) (Type con (Open s))
+    subst' = \case
       Var v -> do
         let e = bug "type instantiation" "unknown variable" (Just $ show v)
         Map.findWithDefault e v <$> ask
-      Fun tx ty -> Fun <$> subst' tx <*> subst' ty
-      App c  ts -> App c <$> traverse subst' ts
-      UVar uref -> do
+      t@Arr     -> pure t
+      t@(Con _) -> pure t
+      App tf tp -> App <$> subst' tf <*> subst' tp
+      t@(UVar uref) -> do
         uvar <- lift $ readSTRef uref
         case uvar of
-          Free{} -> return t
+          Free{}      -> pure t
           Link{_type} -> subst' _type
 
+-- * Deep traversals
+
+-- TODO: Change the order of the parameters of 'Type' and this becomes
+-- 'traverse'.
+type2con :: Traversal (Type con1 Closed) (Type con2 Closed) con1 con2
+type2con f = \case
+  Var v -> pure (Var v)
+  Arr   -> pure Arr
+  Con c -> Con <$> f c
+  App tf tp -> App <$> type2con f tf <*> type2con f tp
+
+-- * Pretty printing
 prettyUVar :: Pretty con => PrettyLevel -> Rational -> UVar con s -> ST s Doc
 prettyUVar lvl prec uvar = case uvar of
   Free{_ident} -> return $ pretty _ident
@@ -154,24 +170,20 @@ prettyUVar lvl prec uvar = case uvar of
 
 prettyType :: Pretty con => PrettyLevel -> Rational -> Type con (Open s) -> ST s Doc
 prettyType lvl prec t = case t of
-  Var v -> return $ pretty v
+  Var v -> pure (pretty v)
+  Arr   -> pure "(->)"
+  Con c -> pure (pretty c)
   Fun tx ty -> do
     px <- prettyType lvl 2 tx
     py <- prettyType lvl 1 ty
-    return $ maybeParens (prec > 1) $ px <+> "->" <+> py
-  App c [] -> return $ pretty c
-  App c ts -> do
-    ps <- traverse (prettyType lvl 3) ts
-    return $ maybeParens (prec > 2) $ pretty c <+> hsep ps
+    pure $ maybeParens (prec > 1) $ px <+> "->" <+> py
+  App tf tx -> do
+    pf <- prettyType lvl 3 tf
+    px <- prettyType lvl 3 tx
+    pure $ maybeParens (prec > 2) $ pf <+> px
   UVar uref -> do
     uvar <- readSTRef uref
     prettyUVar lvl prec uvar
-
-typeCons :: IndexedTraversal [Type con1 Closed] (Type con1 Closed) (Type con2 Closed) con1 con2
-typeCons f = \case
-  Var x    -> pure $ Var x
-  Fun t u  -> Fun <$> typeCons f t <*> typeCons f u
-  App c ts -> App <$> indexed f ts c <*> (traverse . typeCons) f ts
 
 
 instance Pretty (ADT Ident.Con) where

--- a/src/Pukeko/Language/TypeResolver.hs
+++ b/src/Pukeko/Language/TypeResolver.hs
@@ -37,14 +37,11 @@ runTR tr =
 
 -- TODO: Use @typeApps . _1@ to do this.
 trType :: Pos -> Ty.Type Id.Con Ty.Closed -> TR (Ty.Type TR.TypeCon Ty.Closed)
-trType posn typ = case typ of
-    Ty.Var var -> return $ Ty.Var var
-    Ty.Fun tx ty -> Ty.Fun <$> trType posn tx <*> trType posn ty
-    Ty.App con typs -> do
-      adt_opt <- Map.lookup con <$> use typeCons
-      case adt_opt of
-        Nothing -> throwAt posn "unknown type cons" con
-        Just adt -> Ty.App adt <$> traverse (trType posn) typs
+trType w = Ty.type2con $ \con -> do
+  adt_opt <- Map.lookup con <$> use typeCons
+  case adt_opt of
+    Nothing  -> throwAt w "unknown type cons" con
+    Just adt -> pure adt
 
 -- TODO: Have only one insert function.
 insertTypeCon :: Pos -> TR.TypeCon -> TR ()

--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -109,6 +109,7 @@ main = hspec $ beforeAll_ compile $ do
   describe "test basics" $ do
     testBasic "monad_io" [3, 2]  (concat $ replicate 3 [2, 1, 0])
     testBasic "wildcard" [7, 13] [7, 13]
+    testBasic "fix"      (10:[1 .. 10]) [2, 4 .. 20]
   describe "test sorting" $ mapM_ testSort
     [ "isort"
     , "qsort"

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,6 +22,7 @@ SOURCES     = monad_io.pu \
 							catalan.pu \
 							wildcard.pu \
 							rmq.pu \
+							fix.pu \
 							sort_gen.pu \
 							rmq_gen.pu
 LAMBDAS     = $(SOURCES:.pu=.ll)

--- a/test/fix.asm
+++ b/test/fix.asm
@@ -1,0 +1,385 @@
+g_declare_cafs gm$cons_0_0, mapFixList, toList, fromList, main
+g_declare_main main
+
+g_globstart gm$cons_0_0, 0
+g_updcons 0, 0, 1
+g_return
+
+g_globstart gm$cons_0_1, 1
+g_updcons 0, 1, 1
+g_return
+
+g_globstart gm$cons_1_2, 2
+g_updcons 1, 2, 1
+g_return
+
+g_globstart gm$sub, 2
+g_push 1
+g_eval
+g_push 1
+g_eval
+g_sub
+g_update 3
+g_pop 2
+g_return
+
+g_globstart gm$mul, 2
+g_push 1
+g_eval
+g_push 1
+g_eval
+g_mul
+g_update 3
+g_pop 2
+g_return
+
+g_globstart gm$le, 2
+g_push 1
+g_eval
+g_push 1
+g_eval
+g_leq
+g_update 3
+g_pop 2
+g_return
+
+g_globstart foldr, 3
+g_push 2
+g_eval
+g_jumpcase .0, .1
+g_label .0
+g_pop 2
+g_update 2
+g_pop 1
+g_unwind
+g_label .1
+g_uncons 2
+g_push 1
+g_push 4
+g_push 4
+g_pushglobal foldr, 3
+g_mkap 3
+g_push 1
+g_push 4
+g_updap 2, 6
+g_pop 5
+g_unwind
+g_label .2
+
+g_globstart replicate, 2
+g_pushint 0
+g_push 1
+g_eval
+g_leq
+g_jumpcase .0, .1
+g_label .0
+g_pop 1
+g_push 1
+g_pushint 1
+g_push 2
+g_pushglobal gm$sub, 2
+g_mkap 2
+g_pushglobal replicate, 2
+g_mkap 2
+g_push 2
+g_updcons 1, 2, 3
+g_pop 2
+g_return
+g_jump .2
+g_label .1
+g_pop 1
+g_pushglobal gm$cons_0_0, 0
+g_update 3
+g_pop 2
+g_unwind
+g_label .2
+
+g_globstart gm$return, 2
+g_updcons 0, 2, 1
+g_return
+
+g_globstart gm$print, 2
+g_eval
+g_print
+g_cons 0, 0
+g_updcons 0, 2, 1
+g_return
+
+g_globstart gm$input, 1
+g_input
+g_updcons 0, 2, 1
+g_return
+
+g_globstart gm$bind, 3
+g_push 2
+g_push 1
+g_mkap 1
+g_eval
+g_uncons 2
+g_push 3
+g_updap 2, 4
+g_pop 3
+g_unwind
+
+g_globstart op$s$ll1, 2
+g_update 2
+g_pop 1
+g_unwind
+
+g_globstart op$s, 2
+g_push 1
+g_pushglobal op$s$ll1, 2
+g_mkap 1
+g_push 1
+g_pushglobal gm$bind, 3
+g_updap 2, 3
+g_pop 2
+g_unwind
+
+g_globstart sequence_io$ll2, 2
+g_push 1
+g_push 1
+g_cons 1, 2
+g_pushglobal gm$return, 2
+g_updap 1, 3
+g_pop 2
+g_unwind
+
+g_globstart sequence_io$ll1, 2
+g_push 1
+g_pushglobal sequence_io$ll2, 2
+g_mkap 1
+g_push 1
+g_pushglobal sequence_io, 1
+g_mkap 1
+g_pushglobal gm$bind, 3
+g_updap 2, 3
+g_pop 2
+g_unwind
+
+g_globstart sequence_io, 1
+g_push 0
+g_eval
+g_jumpcase .0, .1
+g_label .0
+g_pop 1
+g_pushglobal gm$cons_0_0, 0
+g_pushglobal gm$return, 2
+g_updap 1, 2
+g_pop 1
+g_unwind
+g_label .1
+g_uncons 2
+g_push 1
+g_pushglobal sequence_io$ll1, 2
+g_mkap 1
+g_push 1
+g_pushglobal gm$bind, 3
+g_updap 2, 4
+g_pop 3
+g_unwind
+g_label .2
+
+g_globstart iter_io$ll1, 3
+g_push 2
+g_push 2
+g_push 2
+g_mkap 1
+g_pushglobal op$s, 2
+g_updap 2, 4
+g_pop 3
+g_unwind
+
+g_globstart iter_io, 1
+g_pushglobal gm$cons_0_0, 0
+g_pushglobal gm$return, 2
+g_mkap 1
+g_push 1
+g_pushglobal iter_io$ll1, 3
+g_mkap 1
+g_pushglobal foldr, 3
+g_updap 2, 2
+g_pop 1
+g_unwind
+
+g_globstart id, 1
+g_update 1
+g_unwind
+
+g_globstart cata, 3
+g_push 2
+g_eval
+g_uncons 1
+g_push 0
+g_push 3
+g_push 3
+g_pushglobal cata, 3
+g_mkap 2
+g_push 3
+g_mkap 2
+g_push 3
+g_updap 1, 5
+g_pop 4
+g_unwind
+
+g_globstart ana, 3
+g_push 2
+g_push 2
+g_mkap 1
+g_push 2
+g_push 2
+g_pushglobal ana, 3
+g_mkap 2
+g_push 2
+g_mkap 2
+g_updcons 0, 1, 4
+g_pop 3
+g_return
+
+g_globstart mapFix, 3
+g_push 2
+g_eval
+g_uncons 1
+g_push 0
+g_push 3
+g_push 3
+g_pushglobal mapFix, 3
+g_mkap 2
+g_push 4
+g_push 4
+g_mkap 3
+g_updcons 0, 1, 5
+g_pop 4
+g_return
+
+g_globstart bimapListF, 3
+g_push 2
+g_eval
+g_jumpcase .0, .1
+g_label .0
+g_pop 1
+g_pushglobal gm$cons_0_0, 0
+g_update 4
+g_pop 3
+g_unwind
+g_label .1
+g_uncons 2
+g_push 1
+g_push 4
+g_mkap 1
+g_push 1
+g_push 4
+g_mkap 1
+g_updcons 1, 2, 6
+g_pop 5
+g_return
+g_jump .2
+g_label .2
+
+g_globstart mapFixList, 0
+g_pushglobal bimapListF, 3
+g_pushglobal mapFix, 3
+g_updap 1, 1
+g_unwind
+
+g_globstart toList$ll1, 1
+g_push 0
+g_eval
+g_jumpcase .0, .1
+g_label .0
+g_pop 1
+g_pushglobal gm$cons_0_0, 0
+g_update 2
+g_pop 1
+g_unwind
+g_label .1
+g_uncons 2
+g_push 1
+g_push 1
+g_updcons 1, 2, 4
+g_pop 3
+g_return
+g_jump .2
+g_label .2
+
+g_globstart toList, 0
+g_pushglobal toList$ll1, 1
+g_pushglobal id, 1
+g_pushglobal bimapListF, 3
+g_mkap 1
+g_pushglobal cata, 3
+g_updap 2, 1
+g_unwind
+
+g_globstart fromList$ll1, 1
+g_push 0
+g_eval
+g_jumpcase .0, .1
+g_label .0
+g_pop 1
+g_pushglobal gm$cons_0_0, 0
+g_update 2
+g_pop 1
+g_unwind
+g_label .1
+g_uncons 2
+g_push 1
+g_push 1
+g_updcons 1, 2, 4
+g_pop 3
+g_return
+g_jump .2
+g_label .2
+
+g_globstart fromList, 0
+g_pushglobal fromList$ll1, 1
+g_pushglobal id, 1
+g_pushglobal bimapListF, 3
+g_mkap 1
+g_pushglobal ana, 3
+g_updap 2, 1
+g_unwind
+
+g_globstart main$ll3, 1
+g_push 0
+g_eval
+g_pushint 2
+g_mul
+g_update 2
+g_pop 1
+g_return
+
+g_globstart main$ll2, 1
+g_push 0
+g_pushglobal fromList, 0
+g_mkap 1
+g_pushglobal main$ll3, 1
+g_pushglobal mapFixList, 0
+g_mkap 2
+g_pushglobal toList, 0
+g_mkap 1
+g_pushglobal gm$print, 2
+g_pushglobal iter_io, 1
+g_updap 2, 2
+g_pop 1
+g_unwind
+
+g_globstart main$ll1, 1
+g_pushglobal main$ll2, 1
+g_pushglobal gm$input, 1
+g_push 2
+g_pushglobal replicate, 2
+g_mkap 2
+g_pushglobal sequence_io, 1
+g_mkap 1
+g_pushglobal gm$bind, 3
+g_updap 2, 2
+g_pop 1
+g_unwind
+
+g_globstart main, 0
+g_pushglobal main$ll1, 1
+g_pushglobal gm$input, 1
+g_pushglobal gm$bind, 3
+g_updap 2, 1
+g_unwind

--- a/test/fix.ll
+++ b/test/fix.ll
@@ -1,0 +1,54 @@
+external (-) = "sub"
+external (*) = "mul"
+external (<=) = "le"
+let foldr f y0 xs =
+      match xs with
+      | Nil -> y0
+      | Cons x xs -> f x (foldr f y0 xs)
+let replicate n x =
+      match (<=) n 0 with
+      | False -> Cons x (replicate ((-) n 1) x)
+      | True -> Nil
+external return = "return"
+external print = "print"
+external input = "input"
+external (>>=) = "bind"
+let (;ll1) m2 _ = m2
+let (;) m1 m2 = (>>=) m1 ((;ll1) m2)
+let sequence_io$ll2 x xs = return (Cons x xs)
+let sequence_io$ll1 ms x =
+      (>>=) (sequence_io ms) (sequence_io$ll2 x)
+let sequence_io ms =
+      match ms with
+      | Nil -> return Nil
+      | Cons m ms -> (>>=) m (sequence_io$ll1 ms)
+let iter_io$ll1 f x m = (;) (f x) m
+let iter_io f = foldr (iter_io$ll1 f) (return Unit)
+let id x = x
+let cata fmap f x =
+      match x with
+      | Fix y -> f (fmap (cata fmap f) y)
+let ana fmap f x = Fix (fmap (ana fmap f) (f x))
+let mapFix bimap f x =
+      match x with
+      | Fix y -> Fix (bimap f (mapFix bimap f) y)
+let bimapListF f g x =
+      match x with
+      | NilF -> NilF
+      | ConsF y z -> ConsF (f y) (g z)
+let mapFixList = mapFix bimapListF
+let toList$ll1 x =
+      match x with
+      | NilF -> Nil
+      | ConsF y ys -> Cons y ys
+let toList = cata (bimapListF id) toList$ll1
+let fromList$ll1 x =
+      match x with
+      | Nil -> NilF
+      | Cons y ys -> ConsF y ys
+let fromList = ana (bimapListF id) fromList$ll1
+let main$ll3 x = (*) 2 x
+let main$ll2 xs =
+      iter_io print (toList (mapFixList main$ll3 (fromList xs)))
+let main$ll1 n = (>>=) (sequence_io (replicate n input)) main$ll2
+let main = (>>=) input main$ll1

--- a/test/fix.pu
+++ b/test/fix.pu
@@ -1,0 +1,56 @@
+val id : a -> a
+let id x = x
+
+-- Fixpoint of a functor
+type Fix f =
+  | Fix (f (Fix f))
+
+val cata : ((Fix f -> a) -> f (Fix f) -> f a) -> (f a -> a) -> Fix f -> a
+let rec cata fmap f x =
+  match x with
+  | Fix y -> f (fmap (cata fmap f) y)
+
+val ana : ((a -> Fix f) -> f a -> f (Fix f)) -> (a -> f a) -> a -> Fix f
+let rec ana fmap f x = Fix (fmap (ana fmap f) (f x))
+
+val mapFix : ((a -> b) -> (Fix (f a) -> Fix (f b)) -> f a (Fix (f a)) -> f b (Fix (f b)))
+       -> (a -> b) -> Fix (f a) -> Fix (f b)
+let rec mapFix bimap f x =
+  match x with
+  | Fix y -> Fix (bimap f (mapFix bimap f) y)
+
+
+-- Bifunctor whose fixpoint is isomorphic to lists
+type ListF a b =
+  | NilF
+  | ConsF a b
+
+val bimapListF : (a1 -> a2) -> (b1 -> b2) -> ListF a1 b1 -> ListF a2 b2
+let bimapListF f g x =
+  match x with
+  | NilF      -> NilF
+  | ConsF y z -> ConsF (f y) (g z)
+
+val mapFixList : (a -> b) -> Fix (ListF a) -> Fix (ListF b)
+let mapFixList = mapFix bimapListF
+
+val toList : Fix (ListF a) -> List a
+let toList = cata (bimapListF id) (fun x ->
+  match x with
+  | NilF       -> Nil
+  | ConsF y ys -> Cons y ys)
+
+val fromList : List a -> Fix (ListF a)
+let fromList = ana (bimapListF id) (fun x ->
+  match x with
+  | Nil       -> NilF
+  | Cons y ys -> ConsF y ys)
+
+
+val main : IO Unit
+let main =
+  input
+  >>= fun n ->
+  sequence_io (replicate n input)
+  >>= fun xs ->
+  iter_io print (toList (mapFixList (fun x -> 2*x) (fromList xs)))

--- a/test/reject.pu
+++ b/test/reject.pu
@@ -56,39 +56,39 @@ type Typ =
 -- SUBSECTION type definition
 
 -- TEST underapplication in one definition
--- FAILURE (line 1, column 1): type cons 'Typ1' expects 1 parameters
+-- FAILURE (line 1, column 1): cannot unify kinds _251 -> * and *
 type Typ1 a
 and Typ2 =
   | Con Typ1
 
 -- TEST underapplication in recursive definition
--- FAILURE (line 1, column 1): type cons 'Typ' expects 2 parameters
+-- FAILURE (line 1, column 1): cannot unify kinds _251 -> * and *
 type Typ a b =
   | Con (Typ a)
 
 -- TEST underapplication in two definitions
--- FAILURE (line 1, column 1): type cons 'List' expects 1 parameters
+-- FAILURE (line 1, column 1): cannot unify kinds * -> * and *
 type Typ =
   | Con List
 
 -- TEST overapplication in one definition
--- FAILURE (line 1, column 1): type cons 'Typ1' expects 1 parameters
+-- FAILURE (line 1, column 1): cannot unify kinds * and _254 -> *
 type Typ1 a
 and Typ2 a =
   | Con (Typ1 a a)
 
 -- TEST overapplication in recursive definition
--- FAILURE (line 1, column 1): type cons 'Typ' expects 1 parameters
+-- FAILURE (line 1, column 1): cannot unify kinds * and _252 -> *
 type Typ a =
   | Con (Typ a a)
 
 -- TEST overapplication in two definitions
--- FAILURE (line 1, column 1): type cons 'Int' expects 0 parameters
+-- FAILURE (line 1, column 1): cannot unify kinds * and _251 -> *
 type Typ a =
   | Con (Int a)
 
 -- TEST unbound type variable
--- FAILURE (line 1, column 1): unbound type vars in term cons 'Con'
+-- FAILURE (line 1, column 1): unknown type variable: b
 type Typ a =
   | Con b
 
@@ -100,11 +100,11 @@ type Typ a a =
 -- SUBSECTION function declaration
 
 -- TEST underapplication
--- FAILURE (line 1, column 1): type cons 'List' expects 1 parameters
+-- FAILURE (line 1, column 1): cannot unify kinds * -> * and *
 val bad : List
 
 -- TEST overapplication
--- FAILURE (line 1, column 1): type cons 'Unit' expects 0 parameters
+-- FAILURE (line 1, column 1): cannot unify kinds * and * -> *
 val bad : Unit Int
 
 

--- a/test/reject.pu
+++ b/test/reject.pu
@@ -217,12 +217,12 @@ and g x = f x
 -- SUBSECTION term cons
 
 -- TEST underapplication in expression
--- FAILURE (line 2, column 5): mismatching types Option a and _3 -> Option _3
+-- FAILURE (line 2, column 5): mismatching types Option and (->) _3
 val bad : Option a
 let bad = Some
 
 -- TEST overapplication in expression
--- FAILURE (line 2, column 11): mismatching types Option _2 and _2 -> _4
+-- FAILURE (line 2, column 11): mismatching types Option and (->) _2
 val f : a -> Option a
 let f x = Some x x
 
@@ -248,7 +248,7 @@ val bad : Unit
 let bad = 1
 
 -- TEST type cons vs arrow
--- FAILURE (line 2, column 5): mismatching types Option a and _3 -> _3
+-- FAILURE (line 2, column 5): mismatching types Option and (->) _3
 val bad : Option a
 let bad = fun y -> y
 

--- a/test/reject.pu
+++ b/test/reject.pu
@@ -97,6 +97,31 @@ type Typ a =
 type Typ a a =
   | Con a
 
+-- TEST self application of type variable
+-- FAILURE (line 1, column 1): occurs check
+type Typ f =
+  | Con (f f)
+
+-- TEST type variable of kinds * and * -> *
+-- FAILURE (line 1, column 1): cannot unify kinds * and _252 -> *
+type Typ f a =
+  | Con f (f a)
+
+-- TEST type variable of kinds * -> * and * -> * -> *
+-- FAILURE (line 1, column 1): cannot unify kinds _253 -> * and *
+type Typ f a b =
+  | Con (f a b) (f a)
+
+-- TEST phantom type variable has kind *
+-- FAILURE (line 5, column 1): cannot unify kinds * -> * and *
+type Typ1 a =
+  | Con1
+and Typ2 a b =
+  | Con2 (a b)
+type Typ3 f a =
+  | Con3 (Typ1 f) (Typ2 f a)
+
+
 -- SUBSECTION function declaration
 
 -- TEST underapplication


### PR DESCRIPTION
Support Haskel98 style higher kinded polymorphism:
* type variables can be used in type constructor position
* kind checker also does kind inference
* explicit kind annotations are not possible
* type variables are defaulted to kind star if the kind is ambiguous
* error messages need improvement
* example demonstrating the fixed point of a functor works
* expect tests detect kind errors as expected

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hurryabit/pukeko/2)
<!-- Reviewable:end -->
