### PR TITLE
Elaborate AST with proofs for type class constraints in inferencer

### DIFF
--- a/src/Pukeko/AST/Dict.hs
+++ b/src/Pukeko/AST/Dict.hs
@@ -1,0 +1,32 @@
+module Pukeko.AST.Dict
+  ( Dict (..)
+  , DxBinder
+  , dict2type
+  ) where
+
+import Pukeko.Prelude
+import Pukeko.Pretty
+
+import Data.Aeson.TH
+
+import Pukeko.AST.Name
+import Pukeko.AST.Type
+
+data Dict
+  = DVar DxVar
+  | DDer DxVar [Type] [Dict]
+
+type DxBinder ty = (DxVar, (Class, ty))
+
+dict2type :: Traversal' Dict Type
+dict2type f = \case
+  DVar x -> pure (DVar x)
+  DDer z ts ds -> DDer z <$> traverse f ts <*> (traverse . dict2type) f ds
+
+instance Pretty Dict
+instance PrettyPrec Dict where
+  prettyPrec _prec _dict = "{Dict}"
+
+deriving instance Show Dict
+
+deriveToJSON defaultOptions ''Dict

--- a/src/Pukeko/AST/Expr.hs
+++ b/src/Pukeko/AST/Expr.hs
@@ -60,6 +60,7 @@ import           Unsafe.Coerce
 import           Pukeko.Pretty
 import qualified Pukeko.AST.Operator   as Op
 import           Pukeko.AST.Name
+import           Pukeko.AST.Dict
 import           Pukeko.AST.Type
 import           Pukeko.AST.Language
 
@@ -73,12 +74,12 @@ type TmBinder ty = (TmVar, ty)
 data Arg lg
   =                TmArg (Expr lg)
   | HasTyApp lg => TyArg (TypeOf lg)
-  | HasCxApp lg => CxArg (Class, TypeOf lg)
+  | HasCxApp lg => CxArg (DictOf lg)
 
 data Par lg
   = HasTmAbs lg => TmPar (TmBinder (TypeOf lg))
   | HasTyAbs lg => TyPar TyVar
-  | HasCxAbs lg => CxPar TypeCstr
+  | HasCxAbs lg => CxPar (DxBinder (TypeOf lg))
 
 data BindMode = BindPar | BindRec
 
@@ -124,7 +125,7 @@ pattern ETmApp fun arg = EApp fun (TmArg arg)
 pattern ETyApp :: HasTyApp lg => Expr lg -> TypeOf lg -> Expr lg
 pattern ETyApp fun typ = EApp fun (TyArg typ)
 
-pattern ECxApp :: HasCxApp lg => Expr lg -> (Class, TypeOf lg) -> Expr lg
+pattern ECxApp :: HasCxApp lg => Expr lg -> DictOf lg -> Expr lg
 pattern ECxApp fun cx = EApp fun (CxArg cx)
 
 pattern ETmAbs :: (IsLambda lg ~ True, HasTmAbs lg) =>
@@ -135,7 +136,7 @@ pattern ETyAbs :: (IsLambda lg ~ True, HasTyAbs lg) => TyVar -> Expr lg -> Expr 
 pattern ETyAbs par body = EAbs (TyPar par) body
 
 pattern ECxAbs :: (IsLambda lg ~ True, HasCxAbs lg) =>
-  (Class, TypeOf lg) -> Expr lg -> Expr lg
+  DxBinder (TypeOf lg) -> Expr lg -> Expr lg
 pattern ECxAbs cx body = EAbs (CxPar cx) body
 
 -- * Derived optics
@@ -200,7 +201,7 @@ mkTAbs :: TypeOf lg ~ Type => Par lg -> Type -> Type
 mkTAbs = \case
   TmPar (_, t) -> TFun t
   TyPar v      -> TUni' v
-  CxPar cx     -> TCtx cx
+  CxPar (_, c) -> TCtx c
 
 unEAnn :: IsLambda lg ~ True => Expr lg -> Expr lg
 unEAnn = \case
@@ -215,11 +216,12 @@ instance HasPos  (Bind lg) where getPos = getPos . nameOf
 
 
 -- * Pretty printing
-instance TypeOf st ~ Type => Pretty (Bind st) where
+
+instance IsTyped lg => Pretty (Bind lg) where
   pretty (MkBind (z, t) e) =
     hang (pretty (z ::: t) <+> "=") 2 (prettyPrec 0 e)
 
-prettyBinds :: TypeOf st ~ Type => BindMode -> [Bind st] -> Doc
+prettyBinds :: IsTyped lg => BindMode -> [Bind lg] -> Doc
 prettyBinds mode ds = case ds of
     [] -> impossible  -- maintained invariant
     d0:ds ->
@@ -239,21 +241,21 @@ instance Pretty Atom where
 prettyTyArg :: Type -> Doc
 prettyTyArg t = "@" <> prettyPrec 3 t
 
-instance TypeOf lg ~ Type => Pretty (Arg lg) where
+instance IsTyped lg => Pretty (Arg lg) where
   pretty = \case
-    TmArg e  -> prettyPrec (succ Op.aprec) e
-    TyArg t  -> prettyTyArg t
-    CxArg cx -> braces (prettyCstr cx)
+    TmArg e -> prettyPrec (succ Op.aprec) e
+    TyArg t -> prettyTyArg t
+    CxArg d -> braces (pretty d)
 
 instance TypeOf lg ~ Type => Pretty (Par lg) where
   pretty = \case
     TmPar (x, t) -> parens (pretty (x ::: t))
     TyPar v      -> "@" <> pretty v
-    CxPar cx     -> braces (prettyCstr cx)
+    CxPar (_, c) -> braces (prettyCstr c)
 
-instance TypeOf lg ~ Type => Pretty (Expr lg)
+instance IsTyped lg => Pretty (Expr lg)
 
-instance TypeOf lg ~ Type => PrettyPrec (Expr lg) where
+instance IsTyped lg => PrettyPrec (Expr lg) where
   prettyPrec prec e0 = case e0 of
     ELoc l -> prettyPrec prec l
     EVar x -> pretty x
@@ -283,7 +285,7 @@ instance TypeOf lg ~ Type => PrettyPrec (Expr lg) where
     -- during type inference.
     ETyAnn _ e -> prettyPrec prec e
 
-prettyEAbs :: (TypeOf lg1 ~ Type, TypeOf lg2 ~ Type) =>
+prettyEAbs :: (TypeOf lg1 ~ Type, IsTyped lg2) =>
   Int -> [Par lg1] -> Expr lg2 -> Doc
 prettyEAbs prec pars body
   | null pars = prettyPrec prec body
@@ -291,7 +293,7 @@ prettyEAbs prec pars body
       maybeParens (prec > 0) $
       hang ("fun" <+> hsepMap pretty pars <+> "->") 2 (pretty body)
 
-instance TypeOf lg ~ Type => Pretty (Altn lg) where
+instance IsTyped lg => Pretty (Altn lg) where
   pretty (MkAltn p t) = hang ("|" <+> pretty p <+> "->") 2 (pretty t)
 
 instance TypeOf lg ~ Type => Pretty (Patn lg)
@@ -308,26 +310,26 @@ instance TypeOf lg ~ Type => PrettyPrec (Patn lg) where
       $ pretty c <+> hsepMap (maybe "_" (pretty . fst)) bs
 
 deriving instance                     Show  BindMode
-deriving instance TypeOf lg ~ Type => Show (Bind lg)
-deriving instance TypeOf lg ~ Type => Show (Arg  lg)
-deriving instance TypeOf lg ~ Type => Show (Par  lg)
-deriving instance TypeOf lg ~ Type => Show (Expr lg)
-deriving instance TypeOf lg ~ Type => Show (Altn lg)
+deriving instance IsTyped lg => Show (Bind lg)
+deriving instance IsTyped lg => Show (Arg  lg)
+deriving instance IsTyped lg => Show (Par  lg)
+deriving instance IsTyped lg => Show (Expr lg)
+deriving instance IsTyped lg => Show (Altn lg)
 deriving instance                     Show  Atom
-deriving instance TypeOf lg ~ Type => Show (Patn lg)
+deriving instance IsTyped lg => Show (Patn lg)
 
 deriveToJSON defaultOptions ''BindMode
 deriveToJSON defaultOptions ''Atom
 
-instance TypeOf lg ~ Type => ToJSON (Patn lg) where
+instance IsTyped lg => ToJSON (Patn lg) where
   toJSON = $(mkToJSON defaultOptions ''Patn)
-instance TypeOf lg ~ Type => ToJSON (Altn lg) where
+instance IsTyped lg => ToJSON (Altn lg) where
   toJSON = $(mkToJSON defaultOptions ''Altn)
-instance TypeOf lg ~ Type => ToJSON (Bind lg) where
+instance IsTyped lg => ToJSON (Bind lg) where
   toJSON = $(mkToJSON defaultOptions ''Bind)
-instance TypeOf lg ~ Type => ToJSON (Arg  lg) where
+instance IsTyped lg => ToJSON (Arg  lg) where
   toJSON = $(mkToJSON defaultOptions ''Arg)
-instance TypeOf lg ~ Type => ToJSON (Par  lg) where
+instance IsTyped lg => ToJSON (Par  lg) where
   toJSON = $(mkToJSON defaultOptions ''Par)
-instance TypeOf lg ~ Type => ToJSON (Expr lg) where
+instance IsTyped lg => ToJSON (Expr lg) where
   toJSON = $(mkToJSON defaultOptions ''Expr)

--- a/src/Pukeko/AST/Language.hs
+++ b/src/Pukeko/AST/Language.hs
@@ -8,6 +8,7 @@ module Pukeko.AST.Language
   , SuperCore
 
   , TypeOf
+  , DictOf
   , IsPreTyped
   , IsTyped
   , IsNested
@@ -29,9 +30,10 @@ import Data.Kind (Constraint)
 import GHC.TypeLits (Nat, type (<=?), type (-))
 
 import Pukeko.AST.Type (NoType, Type)
+import Pukeko.AST.Dict (Dict)
 
 data Surface
-data PreTyped (t :: *)
+data PreTyped (t :: *) (d :: *)
 data Typed
 data Unnested
 data Unclassy
@@ -39,31 +41,39 @@ type SystemF = Unclassy
 data SuperCore
 
 type family LangId lg :: Nat where
-  LangId Surface      = 100
-  LangId (PreTyped t) = 399
-  LangId Typed        = 400
-  LangId Unnested     = 500
-  LangId Unclassy     = 600
-  LangId SuperCore    = 700
+  LangId Surface        = 100
+  LangId (PreTyped t d) = 399
+  LangId Typed          = 400
+  LangId Unnested       = 500
+  LangId Unclassy       = 600
+  LangId SuperCore      = 700
 
 type family TypeOf lg :: * where
-  TypeOf Surface      = NoType
-  TypeOf (PreTyped t) = t
-  TypeOf Typed        = Type
-  TypeOf Unnested     = Type
-  TypeOf Unclassy     = Type
-  TypeOf SuperCore    = Type
+  TypeOf Surface        = NoType
+  TypeOf (PreTyped t d) = t
+  TypeOf Typed          = Type
+  TypeOf Unnested       = Type
+  TypeOf Unclassy       = Type
+  TypeOf SuperCore      = Type
 
-type IsPreTyped lg = LangId (PreTyped Type) <=? LangId lg
-type IsTyped    lg = ((LangId Typed <=? LangId lg) ~ True, TypeOf lg ~ Type)
+type family DictOf lg :: * where
+  DictOf Surface        = Void
+  DictOf (PreTyped t d) = d
+  DictOf Typed          = Dict
+  DictOf Unnested       = Dict
+  DictOf Unclassy       = Dict
+  DictOf SuperCore      = Dict
+
+type IsPreTyped lg = LangId (PreTyped Type Dict) <=? LangId lg
+type IsTyped    lg = (TypeOf lg ~ Type, DictOf lg ~ Dict)
 type IsNested   lg = LangId lg <? LangId Unnested
 type IsClassy   lg = LangId lg <? LangId Unclassy
 type IsLambda   lg = LangId lg <? LangId SuperCore
 
 type HasTmAbs lg = (() :: Constraint)
-type HasTyApp lg =                      IsPreTyped lg ~ True
-type HasTyAbs lg =                      TypeOf lg ~ Type
-type HasCxApp lg = (IsClassy lg ~ True, IsPreTyped lg ~ True)
-type HasCxAbs lg = (IsClassy lg ~ True, TypeOf lg ~ Type)
+type HasTyApp lg =  IsPreTyped lg ~ True
+type HasTyAbs lg =  IsPreTyped lg ~ True
+type HasCxApp lg = (IsPreTyped lg ~ True, IsClassy lg ~ True)
+type HasCxAbs lg = (IsPreTyped lg ~ True, IsClassy lg ~ True)
 
 type (<?) m n = m <=? n-1

--- a/src/Pukeko/AST/Name.hs
+++ b/src/Pukeko/AST/Name.hs
@@ -4,6 +4,7 @@ module Pukeko.AST.Name
   ( NameSpace (..)
   , TmVar
   , TyVar
+  , DxVar
   , TmCon
   , TyCon
   , Class
@@ -19,6 +20,7 @@ module Pukeko.AST.Name
   , runSTBelowNameSource
   , mkName
   , copyName
+  , mkDxVar
   , type NameSpaceOf
   , HasName (..)
   ) where
@@ -31,6 +33,7 @@ import           Control.Monad.Freer.State
 import           Control.Monad.ST
 import           Data.Aeson
 import           Data.Aeson.TH
+import           Data.Char (toLower)
 import           Data.Function
 import           Data.Kind
 import           Data.Tagged
@@ -50,6 +53,7 @@ data NameSpace
 -- Saves us a few spaces, but more importantly tons of parentheses.
 type TmVar = Name 'TmVar
 type TyVar = Name 'TyVar
+type DxVar = Name 'TmVar
 
 type TmCon = Name 'TmCon
 type TyCon = Name 'TyCon
@@ -98,6 +102,15 @@ mkName (Lctd pos (Tagged text)) = do
 
 copyName :: Member NameSource effs => SourcePos -> Name nsp -> Eff effs (Name nsp)
 copyName pos (Name _ text _) = mkName (Lctd pos (Tagged text))
+
+mkDxVar :: Member NameSource effs => Class -> TyVar -> Eff effs DxVar
+mkDxVar clss tvar = do
+  let name0 = uncap (untag (nameText clss)) ++ "." ++ untag (nameText tvar)
+  mkName (Lctd noPos (Tagged name0))
+  where
+    uncap = \case
+      x:xs -> toLower x:xs
+      _ -> error "IMPOSSIBLE"
 
 type family NameSpaceOf (a :: Type) :: NameSpace
 

--- a/src/Pukeko/FrontEnd/Inferencer.hs
+++ b/src/Pukeko/FrontEnd/Inferencer.hs
@@ -8,45 +8,38 @@ where
 import Pukeko.Prelude
 import Pukeko.Pretty
 
-import           Control.Lens (folded)
+-- import           Control.Lens (folded)
 import           Control.Monad.Extra
 import           Control.Monad.Freer.Supply
-import           Control.Monad.ST
 import qualified Data.List.NE     as NE
 import qualified Data.Map.Extended as Map
 import qualified Data.Sequence    as Seq
 import qualified Data.Set         as Set
 import           Data.STRef
 
-import           Pukeko.FrontEnd.Info
+import           Pukeko.AST.Dict
 import           Pukeko.AST.Expr.Optics
 import           Pukeko.AST.Name
 import           Pukeko.AST.SystemF
 import           Pukeko.AST.Language
 import           Pukeko.AST.ConDecl
 import           Pukeko.AST.Type       hiding ((~>))
+import           Pukeko.FrontEnd.Inferencer.Constraints
 import           Pukeko.FrontEnd.Inferencer.UType
 import           Pukeko.FrontEnd.Inferencer.Gamma
 import           Pukeko.FrontEnd.Inferencer.Unify
+import           Pukeko.FrontEnd.Info
 
 type In    = Surface
 type Out   = Typed
-type Aux s = PreTyped (UType s)
+type Aux s = PreTyped (UType s) (MDict s)
 
-type UTypeCstrs s = Seq (UTypeCstr s)
-
-data SplitCstrs s = MkSplitCstrs
-  { _retained :: Set (Class, TyVar)
-  , _deferred :: UTypeCstrs s
-  }
-
-type CanInfer s effs =
-  (CanUnify s effs, Members [Supply UVarId, NameSource, Reader ModuleInfo] effs)
+type CanInfer s effs = (CanUnify s effs, CanSolve s effs, Member (Supply UVarId) effs)
 
 freshUVar :: forall s effs. CanInfer s effs => Eff effs (UType s)
 freshUVar = do
   v <- fresh
-  l <- getTLevel @s
+  l <- getLevel @s
   UVar <$> sendM (newSTRef (UFree v l))
 
 generalize :: forall s effs. CanInfer s effs =>
@@ -56,7 +49,7 @@ generalize = go
     go :: UType s -> Eff effs (UType s, Set TyVar)
     go t0 = case t0 of
       UVar uref -> do
-        curLevel <- getTLevel @s
+        curLevel <- getLevel @s
         sendM (readSTRef uref) >>= \case
           UFree uid lvl
             | lvl > curLevel -> do
@@ -77,42 +70,8 @@ generalize = go
       where
         pureDefault = pure (t0, mempty)
 
-splitCstr :: forall s effs. CanInfer s effs => UTypeCstr s -> Eff effs (SplitCstrs s)
-splitCstr (clss, t0) = do
-  (t1, tps) <- sendM (unwindUTApp t0)
-  case t1 of
-    UVar uref -> do
-      cur_level <- getTLevel @s
-      sendM (readSTRef uref) >>= \case
-        UFree v l
-          | l > cur_level ->
-              throwHere
-                ("ambiguous type variable in constraint" <+> pretty clss <+> pretty v)
-          | otherwise -> pure (MkSplitCstrs Set.empty (Seq.singleton (clss, t0)))
-        ULink{} -> impossible  -- we've unwound 'UTApp's
-    UTVar v -> pure (MkSplitCstrs (Set.singleton (clss, v)) mempty)
-    UTAtm atom -> do
-      inst_mb <- lookupInfo info2insts (clss, atom)
-      case inst_mb of
-        Nothing -> throwNoInst
-        Just (SomeInstDecl (MkInstDecl _ _ _ prms cstrs0 _)) -> do
-          let inst = open1 . fmap (Map.fromList (zipExact prms tps) Map.!)
-          let cstrs1 = map (second inst) cstrs0
-          splitCstrs cstrs1
-    UTApp{} -> impossible  -- we've unwound 'UTApp's
-    UTUni{} -> impossible  -- we have only rank-1 types
-    UTCtx{} -> impossible
-  where
-    throwNoInst = do
-      p0 <- sendM (prettyUType 1 t0)
-      throwHere ("TI: no instance for" <+> pretty clss <+> p0)
-
-splitCstrs :: (CanInfer s effs, Traversable t) =>
-  t (UTypeCstr s) -> Eff effs (SplitCstrs s)
-splitCstrs cstrs = fold <$> traverse splitCstr cstrs
-
 instantiate :: CanInfer s effs =>
-  Expr (Aux s) -> UType s -> Eff effs (Expr (Aux s), UType s, UTypeCstrs s)
+  Expr (Aux s) -> UType s -> Eff effs (Expr (Aux s), UType s, UnsolvedCstrs s)
 instantiate = go Map.empty Seq.empty
   where
     go env0 cstrs0 e0 = \case
@@ -120,8 +79,8 @@ instantiate = go Map.empty Seq.empty
         tv <- freshUVar
         go (Map.insert v tv env0) cstrs0 (ETyApp e0 tv) t0
       UTCtx cstr0 t0 -> do
-        cstr1 <- _2 (sendM . substUType env0) cstr0
-        go env0 (cstrs0 Seq.|> cstr1) (ECxApp e0 cstr1) t0
+        (dict, cstr1) <- _2 (sendM . substUType env0) cstr0 >>= freshConstraint
+        go env0 (cstrs0 <> cstr1) (ECxApp e0 dict) t0
       t0 -> do
         t1 <- sendM (substUType env0 t0)
         pure (e0, t1, cstrs0)
@@ -145,48 +104,65 @@ inferPatn patn t_expr = case patn of
     ps1 <- zipWithM inferPatn ps0 t_fields
     pure (PCon dcon ps1)
 
+addTyCxAbs
+  :: [TyVar]
+  -> [DxBinder (UType s)]
+  -> Expr (Aux s)
+  -> UType s
+  -> (Expr (Aux s), UType s)
+addTyCxAbs tyVars dxBinders expr typ
+  | null tyVars && null dxBinders = (expr, typ)
+  | otherwise =
+      ( rewindr ETyAbs tyVars $ rewindr ECxAbs         dxBinders  $ ETyAnn typ expr
+      , rewindr UTUni  tyVars $ rewindr UTCtx (map snd dxBinders) $        typ
+      )
+
 inferLet :: forall s effs.
-  CanInfer s effs => Bind In -> Eff effs (Bind (Aux s), UType s, UTypeCstrs s)
-inferLet (MkBind (l0, NoType) r0) = do
-  (r1, t1, cstrs) <- enterLevel @s (infer r0)
-  (t2, toList -> vs2) <- generalize t1
-  MkSplitCstrs (toList -> rets) defs <- splitCstrs cstrs
-  let t3 = rewindr UTUni vs2 (rewindr UTCtx (map (second UTVar) rets) t2)
-  pure (MkBind (l0, t3) r1, t3, defs)
+  CanInfer s effs => Bind In -> Eff effs (Bind (Aux s), UnsolvedCstrs s)
+inferLet (MkBind (tmVar, NoType) rhs0) = do
+  (rhs1, t'_rhs1, cstrs) <- enterLevel @s (infer rhs0)
+  (t_rhs1, toList -> tyVars) <- generalize t'_rhs1
+  (rets, defs) <- solveConstraints cstrs
+  let (rhs2, t_rhs2) = addTyCxAbs tyVars rets rhs1 t_rhs1
+  pure (MkBind (tmVar, t_rhs2) rhs2, defs)
 
 -- TODO: It would be nice to use Liquid Haskell to show that the resulting lists
 -- have the same length as the input list.
 inferRec :: forall s effs. CanInfer s effs =>
-  [Bind In] -> Eff effs ([Bind (Aux s)], [UType s], UTypeCstrs s)
-inferRec defns0 = do
-  let (ls0, rs0) = unzip (map (\(MkBind (l, NoType) r) -> (l, r)) defns0)
-  (rs1, ts1, cstrs1) <- enterLevel @s $ do
-    us <- traverse (const freshUVar) ls0
-    (rs1, ts1, cstrs1) <-
-      unzip3 <$> withinEScope (Map.fromList (zip ls0 us)) (traverse infer rs0)
-    zipWithM_ unify us ts1
-    pure (rs1, ts1, fold cstrs1)
-  (ts2, vs2) <- second (toList . fold) . unzip <$> traverse generalize ts1
-  MkSplitCstrs rets1 cstrs_def <- splitCstrs cstrs1
-  let rets2 = map (second UTVar) (toList rets1)
-  let qual t2 = rewindr UTUni vs2 (rewindr UTCtx rets2 t2)
-  let ts3 = fmap qual ts2
-  let vs3 = map UTVar vs2
-  let addETyApp x
-        | x `Set.member` Set.fromList ls0 =
-            foldl ECxApp (foldl ETyApp (EVar x) vs3) rets2
+  [Bind In] -> Eff effs ([Bind (Aux s)], UnsolvedCstrs s)
+inferRec binds0 = do
+  let (binders0, rhss0) = unzip (map (\(MkBind (b, NoType) r) -> (b, r)) binds0)
+  (rhss1, t'_rhss1, cstrs1) <- enterLevel @s $ do
+    binders1 <- for binders0 $ \b -> (,) b <$> freshUVar
+    (rhss1, t'_rhss1, cstrs1) <- unzip3 <$> introTmVars binders1 (traverse infer rhss0)
+    zipWithM_ (unify . snd) binders1 t'_rhss1
+    pure (rhss1, t'_rhss1, fold cstrs1)
+  (t_rhss1, toList . fold -> tyVars) <-  unzip <$> traverse generalize t'_rhss1
+  (rets1, defs1) <- solveConstraints cstrs1
+  let dicts = map (MDVar . fst) rets1
+  let bound = Set.fromList binders0
+  let addApps x
+        | x `Set.member` bound =
+            foldl ECxApp (foldl ETyApp (EVar x) (map UTVar tyVars)) dicts
         | otherwise = EVar x
-  let rs2 = map (substitute addETyApp) rs1
-  let defns1 = zipWith3 (\l0 t3 r2 -> MkBind (l0, t3) r2) ls0 ts3 rs2
-  pure (defns1, ts3, cstrs_def)
+  let binds2 =
+        zipWith3
+          (\binder0 rhs1 t_rhs1 ->
+             let (rhs2, t_rhs2) =
+                   addTyCxAbs tyVars rets1 (substitute addApps rhs1) t_rhs1
+              in  MkBind (binder0, t_rhs2) rhs2)
+          binders0
+          rhss1
+          t_rhss1
+  pure (binds2, defs1)
 
 infer :: forall s effs. CanInfer s effs =>
-  Expr In -> Eff effs (Expr (Aux s), UType s, UTypeCstrs s)
+  Expr In -> Eff effs (Expr (Aux s), UType s, UnsolvedCstrs s)
 infer = \case
     ELoc (Lctd pos e0) -> here_ pos $ do
       (e1, t1, cstrs) <- infer e0
       pure (ELoc (Lctd pos e1), t1, cstrs)
-    EVar x -> lookupEVar x >>= instantiate (EVar x)
+    EVar x -> lookupTmVar x >>= instantiate (EVar x)
     EAtm a -> typeOfAtom a >>= instantiate (EAtm a) . open
     EApp fun0 (TmArg arg0) -> do
       (fun1, t_fun, cstrs_fun) <- infer fun0
@@ -196,26 +172,22 @@ infer = \case
       pure (ETmApp fun1 arg1, t_res, cstrs_fun <> cstrs_arg)
     EAbs (TmPar (param, NoType)) body0 -> do
       t_param <- freshUVar
-      (body1, t_body, cstrs) <- withinEScope1 @s param t_param (infer body0)
       let binder = (param, t_param)
+      (body1, t_body, cstrs) <- introTmVar @s binder (infer body0)
       pure (ETmAbs binder (ETyAnn t_body body1), t_param ~> t_body, cstrs)
-    ELet BindPar defns0 rhs0 -> do
-      (defns1, t_defns, cstrs_defns) <- unzip3 <$> traverse inferLet defns0
-      (rhs1, t_rhs, cstrs_rhs) <-
-        withinEScope (Map.fromList (zipExact (map nameOf defns0) t_defns)) (infer rhs0)
-      pure (ELet BindPar defns1 rhs1, t_rhs, fold cstrs_defns <> cstrs_rhs)
-    ELet BindRec defns0 rhs0 -> do
-      (defns1, t_defns, cstrs_defns) <- inferRec defns0
-      (rhs1, t_rhs, cstrs_rhs) <-
-        withinEScope (Map.fromList (zipExact (map nameOf defns0) t_defns)) (infer rhs0)
-      pure (ELet BindRec defns1 rhs1, t_rhs, cstrs_defns <> cstrs_rhs)
+    ELet mode binds0 body0 -> do
+      (binds1, cstrs_binds) <- case mode of
+        BindPar -> second fold . unzip <$> traverse inferLet binds0
+        BindRec -> inferRec binds0
+      (body1, t_body1, cstrs_body) <- introTmVars (map _b2binder binds1) $ infer body0
+      pure (ELet mode binds1 body1, t_body1, cstrs_binds <> cstrs_body)
     EMat NoType expr0 altns0 -> do
       (expr1, t_expr, cstrs0) <- infer expr0
       t_res <- freshUVar
       (altns1, cstrss1) <- fmap NE.unzip . for altns0 $ \(MkAltn patn0 rhs0) -> do
         patn1 <- inferPatn patn0 t_expr
-        let t_binds = Map.fromList (toListOf patn2binder patn1)
-        (rhs1, t_rhs, cstrs1) <- withinEScope t_binds (infer rhs0)
+        let binders = toListOf patn2binder patn1
+        (rhs1, t_rhs, cstrs1) <- introTmVars binders (infer rhs0)
         unify t_res t_rhs
         pure (MkAltn patn1 rhs1, cstrs1)
       pure (EMat t_expr expr1 altns1, t_res, cstrs0 <> fold cstrss1)
@@ -237,25 +209,33 @@ infer = \case
 
 inferFuncDecl :: forall s tv effs. CanInfer s effs =>
   FuncDecl In tv -> UType s -> Eff effs (FuncDecl (Aux s) tv)
-inferFuncDecl (MkFuncDecl name NoType e0) t_decl = do
+inferFuncDecl (MkFuncDecl name NoType body0) t_decl = do
     -- NOTE: We do not instantiate the universally quantified type variables in
     -- prenex position of @t_decl@. Turning them into unification variables
     -- would make the following type check:
     --
-    -- val f : a -> b
-    -- let f = fun x -> x
-    let (vs0, unwindr _UTCtx -> (cstrs0, t0)) = unwindr _UTUni t_decl
-    (e1, t1, cstrs1) <- enterLevel @s (infer e0)
-    -- NOTE: This unification should bind all unification variables in @t1@. If
-    -- it does not, the quantification step will catch them.
-    introTVars @s vs0 $ withinContext cstrs0 $ do
-      unify t0 t1
-      MkSplitCstrs rets1 defs1 <- splitCstrs cstrs1
-      assertM (null defs1)  -- the renamer catches free type variables in constraints
-      for_ rets1 $ \(clss, tvar) ->
-        unlessM (Set.member clss <$> lookupTVar @s tvar) $
-          throwHere ("cannot deduce" <+> pretty clss <+> pretty tvar <+> "from context")
-    pure (MkFuncDecl name t_decl e1)
+    -- f : a -> b
+    -- f = fun x -> x
+    let (vs0, (ctxt0, t_body0)) = second (unwindr _UTCtx) (unwindr _UTUni t_decl)
+    ctxt1 <- for ctxt0 $ \case
+      cstr@(clss, UTVar tvar) -> do
+        dvar <- mkDxVar clss tvar
+        pure (dvar, cstr)
+      _ -> impossible
+    (body1, t_body1, cstrs1) <- enterLevel @s $ infer body0
+    (rets1, defs1) <- introTyVars @s vs0 $ enterContext ctxt1 $ do
+      -- NOTE: This unification should bind all unification variables in @t1@. If
+      -- it does not, the freezing will catch this (and error out).
+      unify t_body0 t_body1
+      solveConstraints cstrs1
+    assertM (null defs1)  -- the renamer catches free type variables in constraints
+    case rets1 of
+      [] -> pure ()
+      (_, (clss, typ)):_ -> do
+        pTyp <- sendM (prettyUType 0 typ)
+        throwHere ("cannot deduce" <+> pretty clss <+> pTyp <+> "from context")
+    let (body2, _) = addTyCxAbs vs0 ctxt1 body1 t_body1
+    pure (MkFuncDecl name t_decl body2)
 
 inferDecl :: forall s effs. CanInfer s effs => Decl In -> Eff effs (Maybe (Decl (Aux s)))
 inferDecl = \case
@@ -269,15 +249,16 @@ inferDecl = \case
     t <- open <$> typeOfFunc name
     yield (DExtn (MkExtnDecl name t s))
   DClss c -> yield (DClss c)
-  DInst (MkInstDecl instName clss atom prms cstrs ds0) -> do
-    ds1 <- for ds0 $ \mthd -> do
-      (_, MkSignDecl _ t_decl0) <- findInfo info2methods (nameOf mthd)
-      let t_inst = foldl TApp (TAtm atom) (map TVar prms)
-      -- FIXME: renameType
-      let t_decl1 = t_decl0 >>= const t_inst
-      introTVars @s prms $ withinContext @s (map (second open) cstrs) $
+  DInst (MkInstDecl instName clss atom prms ctxt0 ds0) -> do
+    let ctxt1 = map (second (second open)) ctxt0
+    introTyVars @s prms $ enterContext @s ctxt1 $ do
+      ds1 <- for ds0 $ \mthd -> do
+        (_, MkSignDecl _ t_decl0) <- findInfo info2methods (nameOf mthd)
+        let t_inst = foldl TApp (TAtm atom) (map TVar prms)
+        -- FIXME: renameType
+        let t_decl1 = t_decl0 >>= const t_inst
         inferFuncDecl mthd (open t_decl1)
-    yield (DInst (MkInstDecl instName clss atom prms cstrs ds1))
+      yield (DInst (MkInstDecl instName clss atom prms ctxt0 ds1))
   where
     yield = pure . Just
 
@@ -291,94 +272,50 @@ inferModule' = module2decls $ \decls ->
                                         & evalSupply uvarIds
                                         & runReader (getPos decl)
 
--- FIXME: We use this set make sure there are /no/ unintended free type variables
--- left in expressions. Make this intention clear through code.
-type TQEnv = Set TyVar
+freezeBind :: Bind (Aux s) -> ST s (Bind Out)
+freezeBind (MkBind (x, t0) e0) = MkBind <$> ((x,) <$> freezeType t0) <*> freezeExpr e0
 
-type TQ s = Eff [Reader TQEnv, Reader SourcePos, Error Failure, NameSource, ST s]
-
-localizeTQ :: Foldable t => t TyVar -> TQ s a -> TQ s a
-localizeTQ qvs = local (setOf folded qvs <>)
-
-qualType :: UType s -> TQ s Type
-qualType = \case
-  UTVar x -> (asks (x `Set.member`) >>= assertM) $> TVar x
-  UTAtm a -> pure (TAtm a)
-  UTApp t1 t2 -> TApp <$> qualType t1 <*> qualType t2
-  UTUni{} -> impossible  -- we have only rank-1 types
-  UTCtx{} -> impossible
-  UVar uref ->
-    sendM (readSTRef uref) >>= \case
-      ULink t -> qualType t
-      UFree{} -> impossible  -- all unification variables have been generalized
-
--- TODO: Rename to 'qualBind'.
-qualDefn :: Bind (Aux s) -> TQ s (Bind Out)
-qualDefn (MkBind (x, t0) e0) = case t0 of
-  UTUni{} -> do
-    let (qvs, unwindr _UTCtx -> (cstrs0, t1)) = unwindr _UTUni t0
-    localizeTQ qvs $ do
-      cstrs1 <- (traverse . _2) qualType cstrs0
-      t1' <- qualType t1
-      let t2  = rewindr TUni' qvs (rewindr TCtx cstrs1 t1')
-      e2  <- rewindr ETyAbs qvs . rewindr ECxAbs cstrs1 . ETyAnn t1' <$> qualExpr e0
-      pure (MkBind (x, t2) e2)
-  _ -> MkBind <$> ((x,) <$> qualType t0) <*> qualExpr e0
-
--- TODO: Write 'qualArg'.
-qualExpr :: Expr (Aux s) -> TQ s (Expr Out)
-qualExpr = \case
-  ELoc le -> here le $ ELoc <$> lctd qualExpr le
+-- TODO: Write 'freezeArg'.
+freezeExpr :: Expr (Aux s) -> ST s (Expr Out)
+freezeExpr = \case
+  ELoc le -> ELoc <$> lctd freezeExpr le
   EVar x -> pure (EVar x)
   EAtm a -> pure (EAtm a)
-  ETmApp fun arg -> ETmApp <$> qualExpr fun <*> qualExpr arg
-  ETyApp e0 t    -> ETyApp <$> qualExpr e0 <*> qualType t
-  ECxApp e cstr  -> ECxApp <$> qualExpr e <*> _2 qualType cstr
+  ETmApp fun arg -> ETmApp <$> freezeExpr fun <*> freezeExpr arg
+  ETyApp e0 t    -> ETyApp <$> freezeExpr e0 <*> freezeType t
+  ECxApp e d -> ECxApp <$> freezeExpr e <*> freezeDict d
   EApp{} -> impossible
-  EAbs (TmPar param) body -> ETmAbs <$> _2 qualType param <*> qualExpr body
-  ELet m ds e0 -> ELet m <$> traverse qualDefn ds <*> qualExpr e0
-  EMat t e0 as -> EMat <$> qualType t <*> qualExpr e0 <*> traverse qualAltn as
-  ECast (c, t) e0 -> ECast . (c,) <$> qualType t <*> qualExpr e0
-  ETyAnn t  e  -> ETyAnn <$> qualType t <*> qualExpr e
+  ETmAbs binder body -> ETmAbs <$> _2 freezeType binder <*> freezeExpr body
+  ETyAbs tvar body -> ETyAbs tvar <$> freezeExpr body
+  ECxAbs binder body -> ECxAbs <$> (_2 . _2) freezeType binder <*> freezeExpr body
+  EAbs{} -> impossible
+  ELet m ds e0 -> ELet m <$> traverse freezeBind ds <*> freezeExpr e0
+  EMat t e0 as -> EMat <$> freezeType t <*> freezeExpr e0 <*> traverse freezeAltn as
+  ECast (c, t) e0 -> ECast . (c,) <$> freezeType t <*> freezeExpr e0
+  ETyAnn t  e  -> ETyAnn <$> freezeType t <*> freezeExpr e
 
-qualAltn :: Altn (Aux s) -> TQ s (Altn Out)
-qualAltn (MkAltn p e) = MkAltn <$> patn2type qualType p <*> qualExpr e
+freezeAltn :: Altn (Aux s) -> ST s (Altn Out)
+freezeAltn (MkAltn p e) = MkAltn <$> patn2type freezeType p <*> freezeExpr e
 
-qualFuncDecl :: FuncDecl (Aux s) tv -> TQ s (FuncDecl Out tv)
-qualFuncDecl (MkFuncDecl name type0 body0) = do
-  MkBind (_, type1) body1 <- qualDefn (MkBind (name, type0) body0)
+freezeFuncDecl :: FuncDecl (Aux s) tv -> ST s (FuncDecl Out tv)
+freezeFuncDecl (MkFuncDecl name type0 body0) = do
+  MkBind (_, type1) body1 <- freezeBind (MkBind (name, type0) body0)
   pure (MkFuncDecl name type1 body1)
 
-qualDecl :: Decl (Aux s) -> TQ s (Decl Out)
-qualDecl = \case
+freezeDecl :: Decl (Aux s) -> ST s (Decl Out)
+freezeDecl = \case
   DType ds -> pure (DType ds)
-  DFunc func -> DFunc <$> qualFuncDecl func
-  DExtn (MkExtnDecl x ts s) -> do
-    t1 <- case ts of
-      UTUni{} -> do
-        let (qvs, t0) = unwindr _UTUni ts
-        localizeTQ qvs (rewindr TUni' qvs <$> qualType t0)
-      t0 -> qualType t0
-    pure (DExtn (MkExtnDecl x t1 s))
-  DClss c -> pure (DClss c)
-  DInst (MkInstDecl instName c t prms cstrs ds0) -> do
-    ds1 <- for ds0 $ \d0 -> localizeTQ prms (qualFuncDecl d0)
-    pure (DInst (MkInstDecl instName c t prms cstrs ds1))
+  DFunc func -> DFunc <$> freezeFuncDecl func
+  DExtn (MkExtnDecl func typ sym) ->
+    DExtn <$> (MkExtnDecl func <$> freezeType typ <*> pure sym)
+  DClss clss -> pure (DClss clss)
+  DInst (MkInstDecl inst clss head prms ctxt mthds) -> do
+    DInst . MkInstDecl inst clss head prms ctxt <$> traverse freezeFuncDecl mthds
 
-qualModule :: Module (Aux s) -> Eff [Error Failure, NameSource, ST s](Module Out)
-qualModule = module2decls . traverse $ \decl ->
-  qualDecl decl
-  & runReader mempty
-  & runReader (getPos decl)
+freezeModule :: Module (Aux s) -> ST s (Module Out)
+freezeModule = module2decls . traverse $ freezeDecl
 
 inferModule :: Members [NameSource, Error Failure] effs =>
   Module In -> Eff effs (Module Out)
-inferModule m0 = eitherM throwError pure $ runSTBelowNameSource $ runError $
-  runInfo m0 (inferModule' m0) >>= qualModule
-
-instance Semigroup (SplitCstrs s) where
-  MkSplitCstrs rs1 ds1 <> MkSplitCstrs rs2 ds2 =
-    MkSplitCstrs (rs1 <> rs2) (ds1 <> ds2)
-
-instance Monoid (SplitCstrs s) where
-  mempty = MkSplitCstrs mempty mempty
+inferModule m0 = eitherM throwFailure pure $ runSTBelowNameSource $ runError $
+  runInfo m0 (inferModule' m0) >>= sendM . freezeModule

--- a/src/Pukeko/FrontEnd/Inferencer/Constraints.hs
+++ b/src/Pukeko/FrontEnd/Inferencer/Constraints.hs
@@ -1,0 +1,115 @@
+module Pukeko.FrontEnd.Inferencer.Constraints where
+
+import Pukeko.Prelude
+
+import qualified Data.Map.Extended as Map
+import qualified Data.Sequence as Seq
+import           Data.STRef
+
+import Pukeko.AST.Dict
+import Pukeko.AST.Name
+import Pukeko.AST.SystemF
+import Pukeko.FrontEnd.Inferencer.UType
+import Pukeko.FrontEnd.Inferencer.Gamma
+import Pukeko.FrontEnd.Info
+
+type CanSolve s effs =
+  ( CanThrowHere effs
+  , CanGamma s effs
+  , Members [NameSource, Reader ModuleInfo] effs
+  , MemberST s effs
+  )
+
+type MDictRef s = STRef s (MDict s)
+
+data MDict s
+  = MDVar DxVar
+  | MDDer DxVar [UType s] [MDict s]
+  | MMeta (MDictRef s)
+  | MTodo
+
+type UnsolvedCstr s = (UTypeCstr s, MDictRef s)
+type UnsolvedCstrs s = Seq (UnsolvedCstr s)
+
+data SplitCstrs s = MkSplitCstrs
+  { _retained :: Seq ((Class, TyVar), MDictRef s)
+  , _deferred :: UnsolvedCstrs s
+  }
+
+freshConstraint :: CanSolve s effs => UTypeCstr s -> Eff effs (MDict s, UnsolvedCstrs s)
+freshConstraint cstr = do
+  dref <- sendM (newSTRef MTodo)
+  pure (MMeta dref, Seq.singleton (cstr, dref))
+
+freezeDict :: MDict s -> ST s Dict
+freezeDict = \case
+  MDVar x -> pure (DVar x)
+  MDDer z ts ds -> DDer z <$> traverse freezeType ts <*> traverse freezeDict ds
+  MTodo -> impossible
+  MMeta dref -> readSTRef dref >>= freezeDict
+
+preSolveConstraint
+  :: forall s effs
+  .  CanSolve s effs
+  => UTypeCstr s
+  -> Eff (Writer (SplitCstrs s) : effs) (MDict s)
+preSolveConstraint cstr@(clss, t0) = do
+  (t1, targs) <- sendM (unwindUTApp t0)
+  case t1 of
+    UVar uref -> do
+      cur_level <- getLevel @s
+      sendM (readSTRef uref) >>= \case
+        UFree v l
+          | l > cur_level ->
+              throwHere
+                ("ambiguous type variable in constraint" <+> pretty clss <+> pretty v)
+          | otherwise -> do
+              dref <- sendM (newSTRef MTodo)
+              tell (MkSplitCstrs mempty (Seq.singleton (cstr, dref)))
+              pure (MMeta dref)
+        ULink{} -> impossible  -- we've unwound 'UTApp's
+    UTVar tvar ->
+      lookupContext @s (clss, tvar) >>= \case
+        Nothing -> do
+          dref <- sendM (newSTRef MTodo)
+          tell (MkSplitCstrs (Seq.singleton ((clss, tvar), dref)) mempty)
+          pure (MMeta dref)
+        Just dvar -> pure (MDVar dvar)
+    UTAtm atom -> do
+      lookupInfo info2insts (clss, atom) >>= \case
+        Nothing -> do
+          p0 <- sendM (prettyUType 1 t0)
+          throwHere ("TI: no instance for" <+> pretty clss <+> p0)
+        Just (SomeInstDecl (MkInstDecl z _ _ prms ctxt _)) -> do
+          -- The kind checker guarantees the number of parameters/arguments to match.
+          let inst = open1 . fmap (Map.fromList (zipExact prms targs) Map.!)
+          MDDer z targs <$> traverse (preSolveConstraint . second inst . snd) ctxt
+    UTApp{} -> impossible  -- we've unwound 'UTApp's
+    UTUni{} -> impossible  -- we have only rank-1 types
+    UTCtx{} -> impossible
+
+solveConstraints
+  :: forall s effs t
+  .  (CanSolve s effs, Foldable t)
+  => t (UnsolvedCstr s)
+  -> Eff effs ([DxBinder (UType s)], UnsolvedCstrs s)
+solveConstraints ucstrs = do
+  ((), MkSplitCstrs rets0 defs) <- runWriter $
+    for_ ucstrs $ \(cstr, dref) -> do
+      dict <- preSolveConstraint @s @effs cstr
+      sendM (writeSTRef dref dict)
+  let rets1 = Map.fromMultiList (toList rets0)
+  rets2 <- for (Map.toList rets1) $ \((clss, tvar), drefs) -> do
+    dvar <- mkDxVar clss tvar
+    let dict = MDVar dvar
+    for_ drefs $ \dref -> sendM (writeSTRef dref dict)
+    pure (dvar, (clss, UTVar tvar))
+  pure (rets2, defs)
+
+
+instance Semigroup (SplitCstrs s) where
+  MkSplitCstrs rets1 defs1 <> MkSplitCstrs rets2 defs2 =
+    MkSplitCstrs (rets1 <> rets2) (defs1 <> defs2)
+
+instance Monoid (SplitCstrs s) where
+  mempty = MkSplitCstrs mempty mempty

--- a/src/Pukeko/FrontEnd/Inferencer/Unify.hs
+++ b/src/Pukeko/FrontEnd/Inferencer/Unify.hs
@@ -8,14 +8,11 @@ where
 
 import Pukeko.Prelude
 
-import           Control.Monad.ST
 import           Data.STRef
 
 import           Pukeko.Pretty
 import           Pukeko.FrontEnd.Inferencer.Gamma
 import           Pukeko.FrontEnd.Inferencer.UType
-
-type MemberST s effs = LastMember (ST s) effs
 
 type CanUnify s effs = (CanThrowHere effs, CanGamma s effs, MemberST s effs)
 
@@ -48,9 +45,7 @@ occursCheck uref1 t2 = case t2 of
             (_, l1) <- readUnwound uref1
             sendM (writeSTRef uref2 (UFree x2 (min l1 l2)))
           ULink t2' -> occursCheck uref1 t2'
-  UTVar v -> do
-    !_ <- lookupTVar @s v  -- NOTE: This is a sanity check.
-    pure ()
+  UTVar v -> checkTyVar @s v
   UTAtm{} -> pure ()
   UTUni{} -> impossible  -- UVar is assumed to be unwound
   UTCtx{} -> impossible

--- a/src/Pukeko/Prelude.hs
+++ b/src/Pukeko/Prelude.hs
@@ -4,6 +4,7 @@ module Pukeko.Prelude
 
   , True
   , False
+  , MemberST
   , Failure
   , CanThrowHere
   , throwFailure
@@ -40,6 +41,7 @@ import Control.Monad.Freer.Error  as X
 import Control.Monad.Freer.Reader as X
 import Control.Monad.Freer.State  as X
 import Control.Monad.Freer.Writer as X
+import Control.Monad.ST           as X (ST)
 
 import Data.Bifunctor        as X
 import Data.CallStack        as X (HasCallStack)
@@ -79,6 +81,8 @@ import           Pukeko.Orphans ()
 
 type True  = 'True
 type False = 'False
+
+type MemberST s effs = LastMember (ST s) effs
 
 type Failure = Doc
 


### PR DESCRIPTION
Currently, the type inferencer can prove that type class constraints are
satifiable but throws the proof away after that. Hence, the type checker and the
type class elimnator have to redo the proof.

This patch changes the type inferencer such that it leaves the constructed
proofs in AST (as values of type `Dict`). The type checker now checks that the
proof if valid and the type class eliminator proof `Dict` into an actual
dictionary value.