### PR TITLE
Add a very limited form of super classes

### DIFF
--- a/src/Pukeko/AST/Dict.hs
+++ b/src/Pukeko/AST/Dict.hs
@@ -1,5 +1,6 @@
 module Pukeko.AST.Dict
-  ( Dict (..)
+  ( NoDict (..)
+  , Dict (..)
   , DxBinder
   , dict2type
   ) where
@@ -12,9 +13,12 @@ import Data.Aeson.TH
 import Pukeko.AST.Name
 import Pukeko.AST.Type
 
+data NoDict = NoDict
+
 data Dict
   = DVar DxVar
   | DDer DxVar [Type] [Dict]
+  | DSub DxVar Class Type Dict
 
 type DxBinder ty = (DxVar, (Class, ty))
 
@@ -22,6 +26,7 @@ dict2type :: Traversal' Dict Type
 dict2type f = \case
   DVar x -> pure (DVar x)
   DDer z ts ds -> DDer z <$> traverse f ts <*> (traverse . dict2type) f ds
+  DSub z c t d -> DSub z c <$> f t <*> dict2type f d
 
 instance Pretty Dict
 instance PrettyPrec Dict where

--- a/src/Pukeko/AST/Language.hs
+++ b/src/Pukeko/AST/Language.hs
@@ -30,7 +30,7 @@ import Data.Kind (Constraint)
 import GHC.TypeLits (Nat, type (<=?), type (-))
 
 import Pukeko.AST.Type (NoType, Type)
-import Pukeko.AST.Dict (Dict)
+import Pukeko.AST.Dict (NoDict, Dict)
 
 data Surface
 data PreTyped (t :: *) (d :: *)
@@ -57,7 +57,7 @@ type family TypeOf lg :: * where
   TypeOf SuperCore      = Type
 
 type family DictOf lg :: * where
-  DictOf Surface        = Void
+  DictOf Surface        = NoDict
   DictOf (PreTyped t d) = d
   DictOf Typed          = Dict
   DictOf Unnested       = Dict

--- a/src/Pukeko/AST/Name.hs
+++ b/src/Pukeko/AST/Name.hs
@@ -21,6 +21,7 @@ module Pukeko.AST.Name
   , mkName
   , copyName
   , copyName'
+  , synthName
   , mkDxVar
   , type NameSpaceOf
   , HasName (..)
@@ -109,6 +110,14 @@ copyName'
   => (String -> String) -> Name nsp1 -> Eff effs (Name nsp2)
 copyName' f (Name _ text _) = mkName (Lctd noPos (Tagged (f text)))
 
+synthName
+  :: Member NameSource effs
+  => SourcePos -> Name nsp1 -> Name nsp2 -> Eff effs (Name nsp3)
+synthName pos name1 name2 = do
+  let name3 = _text name1 ++ "." ++ _text name2
+  mkName (Lctd pos (Tagged name3))
+
+-- TODO: Make it "a.C" rather than "C.a".
 mkDxVar :: Member NameSource effs => Class -> TyVar -> Eff effs DxVar
 mkDxVar clss tvar = do
   let name0 = uncap (untag (nameText clss)) ++ "." ++ untag (nameText tvar)

--- a/src/Pukeko/AST/Surface.hs
+++ b/src/Pukeko/AST/Surface.hs
@@ -86,6 +86,7 @@ data SignDecl = MkSignDecl
 data ClssDecl = MkClssDecl
   { _clss2name  :: LctdName 'TyCon
   , _clss2prm   :: LctdName 'TyVar
+  , _clss2super :: Maybe (LctdName 'TyCon, LctdName 'TyVar)
   , _clss2mthds :: [SignDecl]
   }
 

--- a/src/Pukeko/FrontEnd/ClassEliminator.hs
+++ b/src/Pukeko/FrontEnd/ClassEliminator.hs
@@ -5,6 +5,7 @@ module Pukeko.FrontEnd.ClassEliminator
 import Pukeko.Prelude
 
 import qualified Bound.Scope as B
+import           Data.Maybe (maybeToList)
 import qualified Safe
 
 import           Pukeko.AST.ConDecl
@@ -35,8 +36,9 @@ mkTDict (clss, t) = TApp (TCon clss) t
 -- | Construct the dictionary data type declaration of a type class declaration.
 -- See 'elimClssDecl' for an example.
 dictTyConDecl :: ClassDecl -> TyConDecl
-dictTyConDecl (MkClassDecl clss prm dcon mthds) =
-    let flds = map _sign2type mthds
+dictTyConDecl (MkClassDecl clss prm super dcon mthds) =
+    let superFld = fmap (\(_, superClass) -> mkTDict (superClass, TVar prm)) super
+        flds = maybeToList superFld  ++ map _sign2type mthds
         dconDecl = MkTmConDecl clss dcon 0 flds
     in  MkTyConDecl clss [prm] (Right [dconDecl])
 
@@ -77,13 +79,15 @@ mkProjExpr t_scrut scrut tmcon arity index field t_field = do
 -- >       match dict with
 -- >       | Dict$Traversable @t traverse -> traverse
 elimClssDecl :: ClassDecl -> CE [Decl Out]
-elimClssDecl clssDecl@(MkClassDecl clss prm dcon mthds) = do
+elimClssDecl clssDecl@(MkClassDecl clss prm super dcon mthds0) = do
   let tcon = dictTyConDecl clssDecl
   let cstr = (clss, TVar prm)
-  let numMthds = length mthds
-  sels <- ifor mthds $ \i (MkSignDecl z t_mthd) -> do
+  let dictType = mkTDict cstr
+  let superMthd = fmap (\(z, c) -> MkSignDecl z (mkTDict (c, TVar prm))) super
+  let mthds1 = maybeToList superMthd ++ mthds0
+  let numMthds = length mthds1
+  sels <- ifor mthds1 $ \i (MkSignDecl z t_mthd) -> do
     dictPrm <- mkName (Lctd noPos "dict")
-    let dictType = mkTDict cstr
     projVar <- copyName z
     proj <- mkProjExpr dictType (EVar dictPrm) dcon numMthds i projVar t_mthd
     let body = ETyAbs prm $ ETmAbs (dictPrm, dictType) $ ETyAnn t_mthd proj
@@ -109,8 +113,8 @@ elimClssDecl clssDecl@(MkClassDecl clss prm dcon mthds) = do
 -- >   in
 -- >   Dict$Traversable @List traverse
 elimInstDecl :: InstDecl In -> CE [Decl Out]
-elimInstDecl (MkInstDecl inst clss tatom prms ctxt defns0) = do
-  MkClassDecl _ _ dcon methods0 <- findInfo info2classes clss
+elimInstDecl (MkInstDecl inst clss tatom prms ctxt superI defns0) = do
+  MkClassDecl _ _ superC dcon methods0 <- findInfo info2classes clss
   let t_inst = mkTApp (TAtm tatom) (map TVar prms)
   let t_dict0 = mkTDict (clss, t_inst)
   let mkFuncDecl name type0 body0 = do
@@ -118,20 +122,25 @@ elimInstDecl (MkInstDecl inst clss tatom prms ctxt defns0) = do
         let type1 = rewindr TUni' prms (rewindr TCtx (map snd ctxt) type0)
         let body1 = rewindr ETyAbs prms (rewindr ECxAbs ctxt (ETyAnn type0 body0))
         MkFuncDecl name type1 <$> elimExpr body1
+  -- TODO: Share code between @superDefn@ und @defns1@.
+  superDefn <- for superI $ \dict -> do
+    let (_, super) = Safe.fromJustNote "BUG" superC
+    name1 <- synthName (getPos inst) inst super
+    mkFuncDecl name1 (mkTDict (super, t_inst)) (elimDict dict)
   defns1 <- for methods0 $ \(MkSignDecl mthd _) -> do
     let MkFuncDecl name0 typ_ body =
           Safe.findJustNote "BUG" (\defn -> nameOf defn == mthd) defns0
-    let name1 = Tagged (untag (nameText inst) ++ "." ++ untag (nameText name0))
-    name2 <- mkName (Lctd (getPos name0) name1)
-    mkFuncDecl name2 typ_ body
+    name1 <- synthName (getPos name0) inst name0
+    mkFuncDecl name1 typ_ body
+  let defns2 = maybeToList superDefn ++ defns1
   let e_dcon = foldl ETyApp (ECon dcon) [t_inst]
   let callDefn defn =
         foldl ECxApp
           (foldl ETyApp (EVal (nameOf defn)) (map TVar prms))
           (map (DVar . fst) ctxt)
-  let e_body = foldl ETmApp e_dcon (map callDefn defns1)
+  let e_body = foldl ETmApp e_dcon (map callDefn defns2)
   dictDefn <- mkFuncDecl inst t_dict0 e_body
-  pure (map DFunc (dictDefn : defns1))
+  pure (map DFunc (dictDefn : defns2))
 
 elimDecl :: Decl In -> CE [Decl Out]
 elimDecl = \case
@@ -142,10 +151,11 @@ elimDecl = \case
   DClss clss  -> elimClssDecl clss
   DInst inst  -> elimInstDecl inst
 
-elimDict :: Dict -> Expr Out
+elimDict :: (IsTyped lg, HasTyApp lg) => Dict -> Expr lg
 elimDict = \case
   DVar x -> EVar x
   DDer z ts ds -> foldl ETmApp (foldl ETyApp (EVal z) ts) (map elimDict ds)
+  DSub z _c t d -> ETmApp (ETyApp (EVal z) t) (elimDict d)
 
 elimExpr :: Expr In -> CE (Expr Out)
 elimExpr = \case

--- a/src/Pukeko/FrontEnd/Info.hs
+++ b/src/Pukeko/FrontEnd/Info.hs
@@ -99,13 +99,13 @@ instance IsType (TypeOf st) => HasModuleInfo (SysF.Module st) where
     -- SysF.DExtn (SysF.MkExtnDecl _    TArr _) -> mempty
     SysF.DExtn (SysF.MkExtnDecl func typ_ _) ->
       maybe mempty (signInfo func) (isType typ_)
-    SysF.DClss clssDecl@(SysF.MkClassDecl clss param _dcon mthds) ->
+    SysF.DClss clssDecl@(SysF.MkClassDecl clss param _super _dcon mthds) ->
       let mthds_info = foldFor mthds $ \mthdDecl@(SysF.MkSignDecl mthd typ0) ->
             let typ1 = TUni' param (TCtx (clss, TVar param) typ0)
             in  signInfo mthd typ1
                 <> itemInfo info2methods mthd (clssDecl, mthdDecl)
       in  itemInfo info2classes clss clssDecl <> mthds_info
-    SysF.DInst inst0@(SysF.MkInstDecl dict clss t _ _ _) ->
+    SysF.DInst inst0@(SysF.MkInstDecl dict clss t _ _ _ _) ->
       let inst1 = SomeInstDecl inst0
       in  itemInfo info2insts (clss, t) inst1 <> itemInfo info2dicts dict inst1
 

--- a/src/Pukeko/FrontEnd/Parser.hs
+++ b/src/Pukeko/FrontEnd/Parser.hs
@@ -310,8 +310,13 @@ signDecl = indented
   (\z -> MkSignDecl z <$> typeScheme)
 
 clssDecl :: Parser ClssDecl
-clssDecl =
-  MkClssDecl <$> clasz <*> tyvar <*> (reserved "where" *> aligned (many signDecl))
+clssDecl = do
+  super <- optional (parens ((,) <$> clasz <*> tyvar) <* reservedOp "<=")
+  clss <- clasz
+  tvar <- tyvar
+  reserved "where"
+  mthds <- aligned (many signDecl)
+  pure (MkClssDecl clss tvar super mthds)
 
 instDecl :: Parser InstDecl
 instDecl = do

--- a/src/Pukeko/FrontEnd/PatternMatcher.hs
+++ b/src/Pukeko/FrontEnd/PatternMatcher.hs
@@ -63,7 +63,8 @@ pmDecl = \case
   DFunc func -> DFunc <$> pmFuncDecl func
   DExtn (MkExtnDecl name typ_ extn) -> pure (DExtn (MkExtnDecl name typ_ extn))
   DClss c -> pure (DClss c)
-  DInst i -> DInst <$> (inst2methods . traverse) pmFuncDecl i
+  DInst (MkInstDecl name clss typ prms ctxt super mthds) ->
+    DInst . MkInstDecl name clss typ prms ctxt super <$> traverse pmFuncDecl mthds
 
 compileModule :: Members [NameSource, Error Failure] effs =>
   Module In -> Eff effs (Module Out)

--- a/test/aliasinline.pl
+++ b/test/aliasinline.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 main : IO Unit = coerce @(_ -> IO) (Pair @Unit @World Unit)

--- a/test/catalan.pl
+++ b/test/catalan.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 external abort : forall a. a = "abort"

--- a/test/fibs.pl
+++ b/test/fibs.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 external abort : forall a. a = "abort"

--- a/test/fix.asm
+++ b/test/fix.asm
@@ -1,4 +1,4 @@
-g_declare_globals C.0.0, 0, C.0.1, 1, C.0.2, 2, C.1.2, 2, B.le, 2, B.sub, 2, B.mul, 2, B.seq, 2, B.puti, 1, B.geti, 1, monadIO, 0, print, 0, input, 0, functorFox2, 1, poly, 1, mono, 1, bifunctorListF, 0, main, 0, id.L1, 1, compose.L1, 3, foldableList.foldr.L1, 3, replicate.L1, 2, semi.L1, 2, semi.L2, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, traverse_.L1, 3, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, fix.L1, 1, unFix.L1, 1, cata.L1, 2, ana.L1, 2, fix2.L1, 1, unFix2.L1, 1, functorFox2.map.L1, 2, functorListF.map.L1, 0, bifunctorListF.bimap.L1, 3, toList.L1, 1, fromList.L1, 1, main.L1, 0, main.L2, 1, main.L3, 1
+g_declare_globals C.0.0, 0, C.0.1, 1, C.0.2, 2, C.0.3, 3, C.1.2, 2, B.le, 2, B.sub, 2, B.mul, 2, B.seq, 2, B.puti, 1, B.geti, 1, functorIO, 0, monadIO, 0, print, 0, input, 0, functorFox2, 1, poly, 1, mono, 1, bifunctorListF, 0, main, 0, id.L1, 1, compose.L1, 3, foldableList.foldr.L1, 3, replicate.L1, 2, semi.L1, 2, semi.L2, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, traverse_.L1, 3, functorIO.map.L1, 3, functorIO.map.L2, 2, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, fix.L1, 1, unFix.L1, 1, cata.L1, 2, ana.L1, 2, fix2.L1, 1, unFix2.L1, 1, functorFox2.map.L1, 2, functorListF.map.L1, 0, bifunctorListF.bimap.L1, 3, toList.L1, 1, fromList.L1, 1, main.L1, 0, main.L2, 1, main.L3, 1
 g_declare_main main
 
 g_globstart C.0.0, 0
@@ -11,6 +11,10 @@ g_return
 
 g_globstart C.0.2, 2
 g_updcons 0, 2, 1
+g_return
+
+g_globstart C.0.3, 3
+g_updcons 0, 3, 1
 g_return
 
 g_globstart C.1.2, 2
@@ -65,10 +69,16 @@ g_input
 g_update 1
 g_return
 
+g_globstart functorIO, 0
+g_pushglobal functorIO.map.L2
+g_updcons 0, 1, 1
+g_return
+
 g_globstart monadIO, 0
 g_pushglobal monadIO.bind.L2
 g_pushglobal monadIO.pure.L2
-g_updcons 0, 2, 1
+g_pushglobal functorIO
+g_updcons 0, 3, 1
 g_return
 
 g_globstart print, 0
@@ -220,7 +230,7 @@ g_mkap 1
 g_push 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -233,7 +243,7 @@ g_push 2
 g_cons 1, 2
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 4
@@ -251,7 +261,7 @@ g_pushglobal sequence.L3
 g_mkap 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -267,7 +277,7 @@ g_pop 1
 g_pushglobal C.0.0
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 3
@@ -282,7 +292,7 @@ g_mkap 2
 g_push 1
 g_push 4
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 5
@@ -298,6 +308,28 @@ g_push 1
 g_pushglobal semi.L2
 g_updap 2, 4
 g_pop 3
+g_unwind
+
+g_globstart functorIO.map.L1, 3
+g_push 2
+g_push 2
+g_mkap 1
+g_eval
+g_uncons 2
+g_push 1
+g_push 1
+g_push 4
+g_mkap 1
+g_updcons 0, 2, 6
+g_pop 5
+g_return
+
+g_globstart functorIO.map.L2, 2
+g_push 1
+g_push 1
+g_pushglobal functorIO.map.L1
+g_updap 2, 3
+g_pop 2
 g_unwind
 
 g_globstart monadIO.pure.L2, 1

--- a/test/fix.pl
+++ b/test/fix.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 data Fix f = f (Fix f)
@@ -45,7 +45,9 @@ external mul_int : Int -> Int -> Int = "mul"
 external seq : forall a b. a -> b -> b = "seq"
 external puti : Int -> Unit = "puti"
 external geti : Unit -> Int = "geti"
-monadIO : Monad IO = .Monad @IO monadIO.pure.L2 monadIO.bind.L2
+functorIO : Functor IO = .Functor @IO functorIO.map.L2
+monadIO : Monad IO =
+  .Monad @IO functorIO monadIO.pure.L2 monadIO.bind.L2
 print : Int -> IO Unit = io.L2 @Int @Unit puti
 input : IO Int = coerce @(_ -> IO) (io.L1 @Unit @Int geti Unit)
 functorFox2 : forall p. Bifunctor p -> Functor (Fix2 p) =
@@ -83,29 +85,36 @@ semi.L1 : forall a m. m a -> Unit -> m a =
 semi.L2 : forall a m. Monad m -> m Unit -> m a -> m a =
   fun @a @m (monad.m : Monad m) (m1 : m Unit) (m2 : m a) ->
     (match monad.m with
-     | .Monad _ bind -> bind) @Unit @a m1 (semi.L1 @a @m m2)
+     | .Monad _ _ bind -> bind) @Unit @a m1 (semi.L1 @a @m m2)
 sequence.L1 : forall a m. Monad m -> a -> List a -> m (List a) =
   fun @a @m (monad.m : Monad m) (x : a) (xs : List a) ->
     (match monad.m with
-     | .Monad pure _ -> pure) @(List a) (Cons @a x xs)
+     | .Monad _ pure _ -> pure) @(List a) (Cons @a x xs)
 sequence.L2 : forall a m. Monad m -> List (m a) -> a -> m (List a) =
   fun @a @m (monad.m : Monad m) (ms : List (m a)) (x : a) ->
     (match monad.m with
-     | .Monad _ bind ->
+     | .Monad _ _ bind ->
        bind) @(List a) @(List a) (sequence.L3 @a @m monad.m ms) (sequence.L1 @a @m monad.m x)
 sequence.L3 : forall a m. Monad m -> List (m a) -> m (List a) =
   fun @a @m (monad.m : Monad m) (ms : List (m a)) ->
     match ms with
     | Nil ->
       (match monad.m with
-       | .Monad pure _ -> pure) @(List a) (Nil @a)
+       | .Monad _ pure _ -> pure) @(List a) (Nil @a)
     | Cons m ms ->
       (match monad.m with
-       | .Monad _ bind ->
+       | .Monad _ _ bind ->
          bind) @a @(List a) m (sequence.L2 @a @m monad.m ms)
 traverse_.L1 : forall a m. Monad m -> (a -> m Unit) -> a -> m Unit -> m Unit =
   fun @a @m (monad.m : Monad m) (f : a -> m Unit) (x : a) ->
     semi.L2 @Unit @m monad.m (f x)
+functorIO.map.L1 : forall a b. (a -> b) -> IO a -> World -> Pair b World =
+  fun @a @b (f : a -> b) (mx : IO a) (world0 : World) ->
+    match coerce @(IO -> _) mx world0 with
+    | Pair x world1 -> Pair @b @World (f x) world1
+functorIO.map.L2 : forall a b. (a -> b) -> IO a -> IO b =
+  fun @a @b (f : a -> b) (mx : IO a) ->
+    coerce @(_ -> IO) (functorIO.map.L1 @a @b f mx)
 monadIO.pure.L2 : forall a. a -> IO a =
   fun @a (x : a) -> coerce @(_ -> IO) (Pair @a @World x)
 monadIO.bind.L1 : forall a b. IO a -> (a -> IO b) -> World -> Pair b World =

--- a/test/frontend/type-checker/classes/good-super-complex.golden
+++ b/test/frontend/type-checker/classes/good-super-complex.golden
@@ -1,0 +1,23 @@
+data C a =
+       | .C (a -> a)
+c : forall a. C a -> a -> a =
+  fun @a (dict : C a) ->
+    match dict with
+    | .C c -> c
+data D a =
+       | .D (C a) (a -> a)
+D.C : forall a. D a -> C a =
+  fun @a (dict : D a) ->
+    match dict with
+    | .D D.C _ -> D.C
+d : forall a. D a -> a -> a =
+  fun @a (dict : D a) ->
+    match dict with
+    | .D _ d -> d
+f : forall a. D a -> a -> a =
+  fun @a (d.a : D a) ->
+    let g : forall _5. C _5 -> D _5 -> _5 -> _5 =
+          fun @_5 (c._5 : C _5) (d._5 : D _5) ->
+            fun (x : _5) -> c @_5 c._5 (d @_5 d._5 x)
+    in
+    g @a (D.C @a d.a) d.a

--- a/test/frontend/type-checker/classes/good-super-complex.pu
+++ b/test/frontend/type-checker/classes/good-super-complex.pu
@@ -1,0 +1,8 @@
+class C a where
+  c : a -> a
+class (C a) <= D a where
+  d : a -> a
+f : (D a) => a -> a
+f =
+  let g x = c (d x)
+  in  g

--- a/test/frontend/type-checker/classes/good-super-mono.golden
+++ b/test/frontend/type-checker/classes/good-super-mono.golden
@@ -1,0 +1,23 @@
+data C a =
+       | .C (a -> a)
+c : forall a. C a -> a -> a =
+  fun @a (dict : C a) ->
+    match dict with
+    | .C c -> c
+data D a =
+       | .D (C a) (a -> a)
+D.C : forall a. D a -> C a =
+  fun @a (dict : D a) ->
+    match dict with
+    | .D D.C _ -> D.C
+d : forall a. D a -> a -> a =
+  fun @a (dict : D a) ->
+    match dict with
+    | .D _ d -> d
+cInt : C Int = .C @Int cInt.c
+cInt.c : Int -> Int = fun (x : Int) -> x
+dInt : D Int = .D @Int dInt.C dInt.d
+dInt.C : C Int = cInt
+dInt.d : Int -> Int = c @Int cInt
+f : forall a. D a -> a -> a =
+  fun @a (d.a : D a) -> c @a (D.C @a d.a)

--- a/test/frontend/type-checker/classes/good-super-mono.pu
+++ b/test/frontend/type-checker/classes/good-super-mono.pu
@@ -1,0 +1,10 @@
+class C a where
+  c : a -> a
+class (C a) <= D a where
+  d : a -> a
+instance cInt : C Int where
+  c x = x
+instance dInt : D Int where
+  d = c
+f : (D a) => a -> a
+f = c

--- a/test/frontend/type-checker/classes/good-super-poly.golden
+++ b/test/frontend/type-checker/classes/good-super-poly.golden
@@ -1,0 +1,42 @@
+data C a =
+       | .C (a -> Int)
+c : forall a. C a -> a -> Int =
+  fun @a (dict : C a) ->
+    match dict with
+    | .C c -> c
+data D a =
+       | .D (C a) (a -> Int)
+D.C : forall a. D a -> C a =
+  fun @a (dict : D a) ->
+    match dict with
+    | .D D.C _ -> D.C
+d : forall a. D a -> a -> Int =
+  fun @a (dict : D a) ->
+    match dict with
+    | .D _ d -> d
+data T a =
+       | C a
+cInt : C Int = .C @Int cInt.c
+cInt.c : Int -> Int = fun (x : Int) -> x
+dInt : D Int = .D @Int dInt.C dInt.d
+dInt.C : C Int = cInt
+dInt.d : Int -> Int = fun (x : Int) -> x
+cT : forall a. C a -> C (T a) =
+  fun @a (c.a : C a) -> .C @(T a) (cT.c @a c.a)
+cT.c : forall a. C a -> T a -> Int =
+  fun @a (c.a : C a) ->
+    fun (t : T a) ->
+      match t with
+      | C x -> c @a c.a x
+dT : forall a. D a -> D (T a) =
+  fun @a (d.a : D a) -> .D @(T a) (dT.C @a d.a) (dT.d @a d.a)
+dT.C : forall a. D a -> C (T a) =
+  fun @a (d.a : D a) -> cT @a (D.C @a d.a)
+dT.d : forall a. D a -> T a -> Int =
+  fun @a (d.a : D a) ->
+    fun (t : T a) ->
+      match t with
+      | C x -> d @a d.a x
+f : forall a. D a -> T a -> Int =
+  fun @a (d.a : D a) ->
+    fun (x : T a) -> c @(T a) (cT @a (D.C @a d.a)) x

--- a/test/frontend/type-checker/classes/good-super-poly.pu
+++ b/test/frontend/type-checker/classes/good-super-poly.pu
@@ -1,0 +1,19 @@
+class C a where
+  c : a -> Int
+class (C a) <= D a where
+  d : a -> Int
+data T a = | C a
+instance cInt : C Int where
+  c x = x
+instance dInt : D Int where
+  d x = x
+instance cT : (C a) => C (T a) where
+  c t =
+    match t with
+    | C x -> c x
+instance dT : (D a) => D (T a) where
+  d t =
+    match t with
+    | C x -> d x
+f : (D a) => T a -> Int
+f x = c x

--- a/test/frontend/type-checker/classes/unsat-sub-mono.golden
+++ b/test/frontend/type-checker/classes/unsat-sub-mono.golden
@@ -1,0 +1,1 @@
+test/frontend/type-checker/classes/unsat-sub-mono.pu:6:1: cannot solve constraint D a in context (C a)

--- a/test/frontend/type-checker/classes/unsat-sub-mono.pu
+++ b/test/frontend/type-checker/classes/unsat-sub-mono.pu
@@ -1,0 +1,6 @@
+class C a where
+  c : a -> a
+class (C a) <= D a where
+  d : a -> a
+f : (C a) => a -> a
+f = d

--- a/test/frontend/type-checker/classes/unsat-super-mono.golden
+++ b/test/frontend/type-checker/classes/unsat-super-mono.golden
@@ -1,0 +1,1 @@
+test/frontend/type-checker/classes/unsat-super-mono.pu:5:10: cannot solve constraint C Int

--- a/test/frontend/type-checker/classes/unsat-super-mono.pu
+++ b/test/frontend/type-checker/classes/unsat-super-mono.pu
@@ -1,0 +1,6 @@
+class C a where
+  c : a -> a
+class (C a) <= D a where
+  d : a -> a
+instance dInt : D Int where
+  d x = x

--- a/test/isort.asm
+++ b/test/isort.asm
@@ -1,12 +1,20 @@
-g_declare_globals C.0.0, 0, C.0.2, 2, C.1.2, 2, B.le, 2, B.sub, 2, B.seq, 2, B.puti, 1, B.geti, 1, monadIO, 0, print, 0, input, 0, isort, 1, main, 0, foldableList.foldr.L1, 3, replicate.L1, 2, semi.L1, 2, semi.L2, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, traverse_.L1, 3, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, insert.L1, 2, main.L1, 1, main.L2, 1
+g_declare_globals C.0.0, 0, C.0.1, 1, C.0.2, 2, C.0.3, 3, C.1.2, 2, B.le, 2, B.sub, 2, B.seq, 2, B.puti, 1, B.geti, 1, functorIO, 0, monadIO, 0, print, 0, input, 0, isort, 1, main, 0, foldableList.foldr.L1, 3, replicate.L1, 2, semi.L1, 2, semi.L2, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, traverse_.L1, 3, functorIO.map.L1, 3, functorIO.map.L2, 2, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, insert.L1, 2, main.L1, 1, main.L2, 1
 g_declare_main main
 
 g_globstart C.0.0, 0
 g_updcons 0, 0, 1
 g_return
 
+g_globstart C.0.1, 1
+g_updcons 0, 1, 1
+g_return
+
 g_globstart C.0.2, 2
 g_updcons 0, 2, 1
+g_return
+
+g_globstart C.0.3, 3
+g_updcons 0, 3, 1
 g_return
 
 g_globstart C.1.2, 2
@@ -51,10 +59,16 @@ g_input
 g_update 1
 g_return
 
+g_globstart functorIO, 0
+g_pushglobal functorIO.map.L2
+g_updcons 0, 1, 1
+g_return
+
 g_globstart monadIO, 0
 g_pushglobal monadIO.bind.L2
 g_pushglobal monadIO.pure.L2
-g_updcons 0, 2, 1
+g_pushglobal functorIO
+g_updcons 0, 3, 1
 g_return
 
 g_globstart print, 0
@@ -162,7 +176,7 @@ g_mkap 1
 g_push 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -175,7 +189,7 @@ g_push 2
 g_cons 1, 2
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 4
@@ -193,7 +207,7 @@ g_pushglobal sequence.L3
 g_mkap 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -209,7 +223,7 @@ g_pop 1
 g_pushglobal C.0.0
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 3
@@ -224,7 +238,7 @@ g_mkap 2
 g_push 1
 g_push 4
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 5
@@ -240,6 +254,28 @@ g_push 1
 g_pushglobal semi.L2
 g_updap 2, 4
 g_pop 3
+g_unwind
+
+g_globstart functorIO.map.L1, 3
+g_push 2
+g_push 2
+g_mkap 1
+g_eval
+g_uncons 2
+g_push 1
+g_push 1
+g_push 4
+g_mkap 1
+g_updcons 0, 2, 6
+g_pop 5
+g_return
+
+g_globstart functorIO.map.L2, 2
+g_push 1
+g_push 1
+g_pushglobal functorIO.map.L1
+g_updap 2, 3
+g_pop 2
 g_unwind
 
 g_globstart monadIO.pure.L2, 1

--- a/test/isort.pl
+++ b/test/isort.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 external le_int : Int -> Int -> Bool = "le"
@@ -36,7 +36,9 @@ external sub_int : Int -> Int -> Int = "sub"
 external seq : forall a b. a -> b -> b = "seq"
 external puti : Int -> Unit = "puti"
 external geti : Unit -> Int = "geti"
-monadIO : Monad IO = .Monad @IO monadIO.pure.L2 monadIO.bind.L2
+functorIO : Functor IO = .Functor @IO functorIO.map.L2
+monadIO : Monad IO =
+  .Monad @IO functorIO monadIO.pure.L2 monadIO.bind.L2
 print : Int -> IO Unit = io.L2 @Int @Unit puti
 input : IO Int = coerce @(_ -> IO) (io.L1 @Unit @Int geti Unit)
 isort : List Int -> List Int =
@@ -61,29 +63,36 @@ semi.L1 : forall a m. m a -> Unit -> m a =
 semi.L2 : forall a m. Monad m -> m Unit -> m a -> m a =
   fun @a @m (monad.m : Monad m) (m1 : m Unit) (m2 : m a) ->
     (match monad.m with
-     | .Monad _ bind -> bind) @Unit @a m1 (semi.L1 @a @m m2)
+     | .Monad _ _ bind -> bind) @Unit @a m1 (semi.L1 @a @m m2)
 sequence.L1 : forall a m. Monad m -> a -> List a -> m (List a) =
   fun @a @m (monad.m : Monad m) (x : a) (xs : List a) ->
     (match monad.m with
-     | .Monad pure _ -> pure) @(List a) (Cons @a x xs)
+     | .Monad _ pure _ -> pure) @(List a) (Cons @a x xs)
 sequence.L2 : forall a m. Monad m -> List (m a) -> a -> m (List a) =
   fun @a @m (monad.m : Monad m) (ms : List (m a)) (x : a) ->
     (match monad.m with
-     | .Monad _ bind ->
+     | .Monad _ _ bind ->
        bind) @(List a) @(List a) (sequence.L3 @a @m monad.m ms) (sequence.L1 @a @m monad.m x)
 sequence.L3 : forall a m. Monad m -> List (m a) -> m (List a) =
   fun @a @m (monad.m : Monad m) (ms : List (m a)) ->
     match ms with
     | Nil ->
       (match monad.m with
-       | .Monad pure _ -> pure) @(List a) (Nil @a)
+       | .Monad _ pure _ -> pure) @(List a) (Nil @a)
     | Cons m ms ->
       (match monad.m with
-       | .Monad _ bind ->
+       | .Monad _ _ bind ->
          bind) @a @(List a) m (sequence.L2 @a @m monad.m ms)
 traverse_.L1 : forall a m. Monad m -> (a -> m Unit) -> a -> m Unit -> m Unit =
   fun @a @m (monad.m : Monad m) (f : a -> m Unit) (x : a) ->
     semi.L2 @Unit @m monad.m (f x)
+functorIO.map.L1 : forall a b. (a -> b) -> IO a -> World -> Pair b World =
+  fun @a @b (f : a -> b) (mx : IO a) (world0 : World) ->
+    match coerce @(IO -> _) mx world0 with
+    | Pair x world1 -> Pair @b @World (f x) world1
+functorIO.map.L2 : forall a b. (a -> b) -> IO a -> IO b =
+  fun @a @b (f : a -> b) (mx : IO a) ->
+    coerce @(_ -> IO) (functorIO.map.L1 @a @b f mx)
 monadIO.pure.L2 : forall a. a -> IO a =
   fun @a (x : a) -> coerce @(_ -> IO) (Pair @a @World x)
 monadIO.bind.L1 : forall a b. IO a -> (a -> IO b) -> World -> Pair b World =

--- a/test/lambdalift.pl
+++ b/test/lambdalift.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 external add_int : Int -> Int -> Int = "add"

--- a/test/monad_io.asm
+++ b/test/monad_io.asm
@@ -1,12 +1,20 @@
-g_declare_globals C.0.0, 0, C.0.2, 2, B.ge, 2, B.gt, 2, B.sub, 2, B.seq, 2, B.puti, 1, B.geti, 1, monadIO, 0, print, 0, input, 0, count_down, 1, main, 0, semi.L1, 2, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, repeat.L1, 3, main.L1, 2, main.L2, 1
+g_declare_globals C.0.0, 0, C.0.1, 1, C.0.2, 2, C.0.3, 3, B.ge, 2, B.gt, 2, B.sub, 2, B.seq, 2, B.puti, 1, B.geti, 1, functorIO, 0, monadIO, 0, print, 0, input, 0, count_down, 1, main, 0, semi.L1, 2, functorIO.map.L1, 3, functorIO.map.L2, 2, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, repeat.L1, 3, main.L1, 2, main.L2, 1
 g_declare_main main
 
 g_globstart C.0.0, 0
 g_updcons 0, 0, 1
 g_return
 
+g_globstart C.0.1, 1
+g_updcons 0, 1, 1
+g_return
+
 g_globstart C.0.2, 2
 g_updcons 0, 2, 1
+g_return
+
+g_globstart C.0.3, 3
+g_updcons 0, 3, 1
 g_return
 
 g_globstart B.ge, 2
@@ -57,10 +65,16 @@ g_input
 g_update 1
 g_return
 
+g_globstart functorIO, 0
+g_pushglobal functorIO.map.L2
+g_updcons 0, 1, 1
+g_return
+
 g_globstart monadIO, 0
 g_pushglobal monadIO.bind.L2
 g_pushglobal monadIO.pure.L2
-g_updcons 0, 2, 1
+g_pushglobal functorIO
+g_updcons 0, 3, 1
 g_return
 
 g_globstart print, 0
@@ -126,6 +140,28 @@ g_unwind
 g_globstart semi.L1, 2
 g_update 2
 g_pop 1
+g_unwind
+
+g_globstart functorIO.map.L1, 3
+g_push 2
+g_push 2
+g_mkap 1
+g_eval
+g_uncons 2
+g_push 1
+g_push 1
+g_push 4
+g_mkap 1
+g_updcons 0, 2, 6
+g_pop 5
+g_return
+
+g_globstart functorIO.map.L2, 2
+g_push 1
+g_push 1
+g_pushglobal functorIO.map.L1
+g_updap 2, 3
+g_pop 2
 g_unwind
 
 g_globstart monadIO.pure.L2, 1
@@ -196,7 +232,7 @@ g_mkap 1
 g_push 5
 g_push 4
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_mkap 2
@@ -209,7 +245,7 @@ g_pop 1
 g_pushglobal C.0.0
 g_push 3
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 6

--- a/test/primes.pl
+++ b/test/primes.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 external abort : forall a. a = "abort"

--- a/test/qsort.asm
+++ b/test/qsort.asm
@@ -1,12 +1,20 @@
-g_declare_globals C.0.0, 0, C.0.2, 2, C.1.2, 2, B.lt, 2, B.le, 2, B.sub, 2, B.seq, 2, B.puti, 1, B.geti, 1, monadIO, 0, print, 0, input, 0, qsort, 1, main, 0, monoidList.empty, 0, monoidList.append.L1, 2, foldableList.foldr.L1, 3, replicate.L1, 2, partition.L1, 2, semi.L1, 2, semi.L2, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, traverse_.L1, 3, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, qsort.L1, 2, main.L1, 1, main.L2, 1
+g_declare_globals C.0.0, 0, C.0.1, 1, C.0.2, 2, C.0.3, 3, C.1.2, 2, B.lt, 2, B.le, 2, B.sub, 2, B.seq, 2, B.puti, 1, B.geti, 1, functorIO, 0, monadIO, 0, print, 0, input, 0, qsort, 1, main, 0, monoidList.empty, 0, monoidList.append.L1, 2, foldableList.foldr.L1, 3, replicate.L1, 2, partition.L1, 2, semi.L1, 2, semi.L2, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, traverse_.L1, 3, functorIO.map.L1, 3, functorIO.map.L2, 2, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, qsort.L1, 2, main.L1, 1, main.L2, 1
 g_declare_main main
 
 g_globstart C.0.0, 0
 g_updcons 0, 0, 1
 g_return
 
+g_globstart C.0.1, 1
+g_updcons 0, 1, 1
+g_return
+
 g_globstart C.0.2, 2
 g_updcons 0, 2, 1
+g_return
+
+g_globstart C.0.3, 3
+g_updcons 0, 3, 1
 g_return
 
 g_globstart C.1.2, 2
@@ -61,10 +69,16 @@ g_input
 g_update 1
 g_return
 
+g_globstart functorIO, 0
+g_pushglobal functorIO.map.L2
+g_updcons 0, 1, 1
+g_return
+
 g_globstart monadIO, 0
 g_pushglobal monadIO.bind.L2
 g_pushglobal monadIO.pure.L2
-g_updcons 0, 2, 1
+g_pushglobal functorIO
+g_updcons 0, 3, 1
 g_return
 
 g_globstart print, 0
@@ -254,7 +268,7 @@ g_mkap 1
 g_push 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -267,7 +281,7 @@ g_push 2
 g_cons 1, 2
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 4
@@ -285,7 +299,7 @@ g_pushglobal sequence.L3
 g_mkap 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -301,7 +315,7 @@ g_pop 1
 g_pushglobal C.0.0
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 3
@@ -316,7 +330,7 @@ g_mkap 2
 g_push 1
 g_push 4
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 5
@@ -332,6 +346,28 @@ g_push 1
 g_pushglobal semi.L2
 g_updap 2, 4
 g_pop 3
+g_unwind
+
+g_globstart functorIO.map.L1, 3
+g_push 2
+g_push 2
+g_mkap 1
+g_eval
+g_uncons 2
+g_push 1
+g_push 1
+g_push 4
+g_mkap 1
+g_updcons 0, 2, 6
+g_pop 5
+g_return
+
+g_globstart functorIO.map.L2, 2
+g_push 1
+g_push 1
+g_pushglobal functorIO.map.L1
+g_updap 2, 3
+g_pop 2
 g_unwind
 
 g_globstart monadIO.pure.L2, 1

--- a/test/qsort.pl
+++ b/test/qsort.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 external lt_int : Int -> Int -> Bool = "lt"
@@ -37,7 +37,9 @@ external sub_int : Int -> Int -> Int = "sub"
 external seq : forall a b. a -> b -> b = "seq"
 external puti : Int -> Unit = "puti"
 external geti : Unit -> Int = "geti"
-monadIO : Monad IO = .Monad @IO monadIO.pure.L2 monadIO.bind.L2
+functorIO : Functor IO = .Functor @IO functorIO.map.L2
+monadIO : Monad IO =
+  .Monad @IO functorIO monadIO.pure.L2 monadIO.bind.L2
 print : Int -> IO Unit = io.L2 @Int @Unit puti
 input : IO Int = coerce @(_ -> IO) (io.L1 @Unit @Int geti Unit)
 qsort : List Int -> List Int =
@@ -83,29 +85,36 @@ semi.L1 : forall a m. m a -> Unit -> m a =
 semi.L2 : forall a m. Monad m -> m Unit -> m a -> m a =
   fun @a @m (monad.m : Monad m) (m1 : m Unit) (m2 : m a) ->
     (match monad.m with
-     | .Monad _ bind -> bind) @Unit @a m1 (semi.L1 @a @m m2)
+     | .Monad _ _ bind -> bind) @Unit @a m1 (semi.L1 @a @m m2)
 sequence.L1 : forall a m. Monad m -> a -> List a -> m (List a) =
   fun @a @m (monad.m : Monad m) (x : a) (xs : List a) ->
     (match monad.m with
-     | .Monad pure _ -> pure) @(List a) (Cons @a x xs)
+     | .Monad _ pure _ -> pure) @(List a) (Cons @a x xs)
 sequence.L2 : forall a m. Monad m -> List (m a) -> a -> m (List a) =
   fun @a @m (monad.m : Monad m) (ms : List (m a)) (x : a) ->
     (match monad.m with
-     | .Monad _ bind ->
+     | .Monad _ _ bind ->
        bind) @(List a) @(List a) (sequence.L3 @a @m monad.m ms) (sequence.L1 @a @m monad.m x)
 sequence.L3 : forall a m. Monad m -> List (m a) -> m (List a) =
   fun @a @m (monad.m : Monad m) (ms : List (m a)) ->
     match ms with
     | Nil ->
       (match monad.m with
-       | .Monad pure _ -> pure) @(List a) (Nil @a)
+       | .Monad _ pure _ -> pure) @(List a) (Nil @a)
     | Cons m ms ->
       (match monad.m with
-       | .Monad _ bind ->
+       | .Monad _ _ bind ->
          bind) @a @(List a) m (sequence.L2 @a @m monad.m ms)
 traverse_.L1 : forall a m. Monad m -> (a -> m Unit) -> a -> m Unit -> m Unit =
   fun @a @m (monad.m : Monad m) (f : a -> m Unit) (x : a) ->
     semi.L2 @Unit @m monad.m (f x)
+functorIO.map.L1 : forall a b. (a -> b) -> IO a -> World -> Pair b World =
+  fun @a @b (f : a -> b) (mx : IO a) (world0 : World) ->
+    match coerce @(IO -> _) mx world0 with
+    | Pair x world1 -> Pair @b @World (f x) world1
+functorIO.map.L2 : forall a b. (a -> b) -> IO a -> IO b =
+  fun @a @b (f : a -> b) (mx : IO a) ->
+    coerce @(_ -> IO) (functorIO.map.L1 @a @b f mx)
 monadIO.pure.L2 : forall a. a -> IO a =
   fun @a (x : a) -> coerce @(_ -> IO) (Pair @a @World x)
 monadIO.bind.L1 : forall a b. IO a -> (a -> IO b) -> World -> Pair b World =

--- a/test/queens.pl
+++ b/test/queens.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 external eq_int : Int -> Int -> Bool = "eq"

--- a/test/rmq.asm
+++ b/test/rmq.asm
@@ -1,12 +1,20 @@
-g_declare_globals C.0.0, 0, C.0.2, 2, C.1.0, 0, C.1.2, 2, C.1.5, 5, B.abort, 0, B.lt, 2, B.le, 2, B.gt, 2, B.add, 2, B.sub, 2, B.seq, 2, B.puti, 1, B.geti, 1, monadIO, 0, print, 0, input, 0, nats, 0, infinity, 0, main, 0, replicate.L1, 2, zip_with.L1, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, nats.L1, 2, pair.L1, 2, single.L1, 2, combine.L1, 3, build.L1, 3, query.L1, 6, min.L1, 2, main.L1, 3, main.L2, 2, main.L3, 1, main.L4, 2, main.L5, 2, main.L6, 1
+g_declare_globals C.0.0, 0, C.0.1, 1, C.0.2, 2, C.0.3, 3, C.1.0, 0, C.1.2, 2, C.1.5, 5, B.abort, 0, B.lt, 2, B.le, 2, B.gt, 2, B.add, 2, B.sub, 2, B.seq, 2, B.puti, 1, B.geti, 1, functorIO, 0, monadIO, 0, print, 0, input, 0, nats, 0, infinity, 0, main, 0, replicate.L1, 2, zip_with.L1, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, functorIO.map.L1, 3, functorIO.map.L2, 2, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, nats.L1, 2, pair.L1, 2, single.L1, 2, combine.L1, 3, build.L1, 3, query.L1, 6, min.L1, 2, main.L1, 3, main.L2, 2, main.L3, 1, main.L4, 2, main.L5, 2, main.L6, 1
 g_declare_main main
 
 g_globstart C.0.0, 0
 g_updcons 0, 0, 1
 g_return
 
+g_globstart C.0.1, 1
+g_updcons 0, 1, 1
+g_return
+
 g_globstart C.0.2, 2
 g_updcons 0, 2, 1
+g_return
+
+g_globstart C.0.3, 3
+g_updcons 0, 3, 1
 g_return
 
 g_globstart C.1.0, 0
@@ -92,10 +100,16 @@ g_input
 g_update 1
 g_return
 
+g_globstart functorIO, 0
+g_pushglobal functorIO.map.L2
+g_updcons 0, 1, 1
+g_return
+
 g_globstart monadIO, 0
 g_pushglobal monadIO.bind.L2
 g_pushglobal monadIO.pure.L2
-g_updcons 0, 2, 1
+g_pushglobal functorIO
+g_updcons 0, 3, 1
 g_return
 
 g_globstart print, 0
@@ -208,7 +222,7 @@ g_push 2
 g_cons 1, 2
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 4
@@ -226,7 +240,7 @@ g_pushglobal sequence.L3
 g_mkap 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -242,7 +256,7 @@ g_pop 1
 g_pushglobal C.0.0
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 3
@@ -257,13 +271,35 @@ g_mkap 2
 g_push 1
 g_push 4
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 5
 g_pop 4
 g_unwind
 g_label .2
+
+g_globstart functorIO.map.L1, 3
+g_push 2
+g_push 2
+g_mkap 1
+g_eval
+g_uncons 2
+g_push 1
+g_push 1
+g_push 4
+g_mkap 1
+g_updcons 0, 2, 6
+g_pop 5
+g_return
+
+g_globstart functorIO.map.L2, 2
+g_push 1
+g_push 1
+g_pushglobal functorIO.map.L1
+g_updap 2, 3
+g_pop 2
+g_unwind
 
 g_globstart monadIO.pure.L2, 1
 g_push 0

--- a/test/rmq_gen.asm
+++ b/test/rmq_gen.asm
@@ -1,12 +1,20 @@
-g_declare_globals C.0.0, 0, C.0.2, 2, C.1.2, 2, B.lt, 2, B.le, 2, B.sub, 2, B.mul, 2, B.mod, 2, B.seq, 2, B.puti, 1, monadIO, 0, print, 0, random, 0, main, 0, foldableList.foldr.L1, 3, take.L1, 2, zip_with.L1, 3, semi.L1, 2, semi.L2, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, traverse_.L1, 3, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, gen.L1, 2, split_at.L1, 2, random.L1, 1, main.L1, 3, main.L2, 1
+g_declare_globals C.0.0, 0, C.0.1, 1, C.0.2, 2, C.0.3, 3, C.1.2, 2, B.lt, 2, B.le, 2, B.sub, 2, B.mul, 2, B.mod, 2, B.seq, 2, B.puti, 1, functorIO, 0, monadIO, 0, print, 0, random, 0, main, 0, foldableList.foldr.L1, 3, take.L1, 2, zip_with.L1, 3, semi.L1, 2, semi.L2, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, traverse_.L1, 3, functorIO.map.L1, 3, functorIO.map.L2, 2, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, gen.L1, 2, split_at.L1, 2, random.L1, 1, main.L1, 3, main.L2, 1
 g_declare_main main
 
 g_globstart C.0.0, 0
 g_updcons 0, 0, 1
 g_return
 
+g_globstart C.0.1, 1
+g_updcons 0, 1, 1
+g_return
+
 g_globstart C.0.2, 2
 g_updcons 0, 2, 1
+g_return
+
+g_globstart C.0.3, 3
+g_updcons 0, 3, 1
 g_return
 
 g_globstart C.1.2, 2
@@ -75,10 +83,16 @@ g_print
 g_updcons 0, 0, 1
 g_return
 
+g_globstart functorIO, 0
+g_pushglobal functorIO.map.L2
+g_updcons 0, 1, 1
+g_return
+
 g_globstart monadIO, 0
 g_pushglobal monadIO.bind.L2
 g_pushglobal monadIO.pure.L2
-g_updcons 0, 2, 1
+g_pushglobal functorIO
+g_updcons 0, 3, 1
 g_return
 
 g_globstart print, 0
@@ -289,7 +303,7 @@ g_mkap 1
 g_push 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -302,7 +316,7 @@ g_push 2
 g_cons 1, 2
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 4
@@ -320,7 +334,7 @@ g_pushglobal sequence.L3
 g_mkap 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -336,7 +350,7 @@ g_pop 1
 g_pushglobal C.0.0
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 3
@@ -351,7 +365,7 @@ g_mkap 2
 g_push 1
 g_push 4
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 5
@@ -367,6 +381,28 @@ g_push 1
 g_pushglobal semi.L2
 g_updap 2, 4
 g_pop 3
+g_unwind
+
+g_globstart functorIO.map.L1, 3
+g_push 2
+g_push 2
+g_mkap 1
+g_eval
+g_uncons 2
+g_push 1
+g_push 1
+g_push 4
+g_mkap 1
+g_updcons 0, 2, 6
+g_pop 5
+g_return
+
+g_globstart functorIO.map.L2, 2
+g_push 1
+g_push 1
+g_pushglobal functorIO.map.L1
+g_updap 2, 3
+g_pop 2
 g_unwind
 
 g_globstart monadIO.pure.L2, 1

--- a/test/rmq_gen.pl
+++ b/test/rmq_gen.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 external lt_int : Int -> Int -> Bool = "lt"
@@ -38,7 +38,9 @@ external mul_int : Int -> Int -> Int = "mul"
 external mod : Int -> Int -> Int = "mod"
 external seq : forall a b. a -> b -> b = "seq"
 external puti : Int -> Unit = "puti"
-monadIO : Monad IO = .Monad @IO monadIO.pure.L2 monadIO.bind.L2
+functorIO : Functor IO = .Functor @IO functorIO.map.L2
+monadIO : Monad IO =
+  .Monad @IO functorIO monadIO.pure.L2 monadIO.bind.L2
 print : Int -> IO Unit = io.L2 @Int @Unit puti
 random : List Int = gen.L1 @Int random.L1 1
 main : IO Unit =
@@ -93,29 +95,36 @@ semi.L1 : forall a m. m a -> Unit -> m a =
 semi.L2 : forall a m. Monad m -> m Unit -> m a -> m a =
   fun @a @m (monad.m : Monad m) (m1 : m Unit) (m2 : m a) ->
     (match monad.m with
-     | .Monad _ bind -> bind) @Unit @a m1 (semi.L1 @a @m m2)
+     | .Monad _ _ bind -> bind) @Unit @a m1 (semi.L1 @a @m m2)
 sequence.L1 : forall a m. Monad m -> a -> List a -> m (List a) =
   fun @a @m (monad.m : Monad m) (x : a) (xs : List a) ->
     (match monad.m with
-     | .Monad pure _ -> pure) @(List a) (Cons @a x xs)
+     | .Monad _ pure _ -> pure) @(List a) (Cons @a x xs)
 sequence.L2 : forall a m. Monad m -> List (m a) -> a -> m (List a) =
   fun @a @m (monad.m : Monad m) (ms : List (m a)) (x : a) ->
     (match monad.m with
-     | .Monad _ bind ->
+     | .Monad _ _ bind ->
        bind) @(List a) @(List a) (sequence.L3 @a @m monad.m ms) (sequence.L1 @a @m monad.m x)
 sequence.L3 : forall a m. Monad m -> List (m a) -> m (List a) =
   fun @a @m (monad.m : Monad m) (ms : List (m a)) ->
     match ms with
     | Nil ->
       (match monad.m with
-       | .Monad pure _ -> pure) @(List a) (Nil @a)
+       | .Monad _ pure _ -> pure) @(List a) (Nil @a)
     | Cons m ms ->
       (match monad.m with
-       | .Monad _ bind ->
+       | .Monad _ _ bind ->
          bind) @a @(List a) m (sequence.L2 @a @m monad.m ms)
 traverse_.L1 : forall a m. Monad m -> (a -> m Unit) -> a -> m Unit -> m Unit =
   fun @a @m (monad.m : Monad m) (f : a -> m Unit) (x : a) ->
     semi.L2 @Unit @m monad.m (f x)
+functorIO.map.L1 : forall a b. (a -> b) -> IO a -> World -> Pair b World =
+  fun @a @b (f : a -> b) (mx : IO a) (world0 : World) ->
+    match coerce @(IO -> _) mx world0 with
+    | Pair x world1 -> Pair @b @World (f x) world1
+functorIO.map.L2 : forall a b. (a -> b) -> IO a -> IO b =
+  fun @a @b (f : a -> b) (mx : IO a) ->
+    coerce @(_ -> IO) (functorIO.map.L1 @a @b f mx)
 monadIO.pure.L2 : forall a. a -> IO a =
   fun @a (x : a) -> coerce @(_ -> IO) (Pair @a @World x)
 monadIO.bind.L1 : forall a b. IO a -> (a -> IO b) -> World -> Pair b World =

--- a/test/sort_gen.asm
+++ b/test/sort_gen.asm
@@ -1,12 +1,20 @@
-g_declare_globals C.0.0, 0, C.0.2, 2, C.1.2, 2, B.le, 2, B.sub, 2, B.mul, 2, B.mod, 2, B.seq, 2, B.puti, 1, B.geti, 1, monadIO, 0, print, 0, input, 0, main, 0, foldableList.foldr.L1, 3, take.L1, 2, semi.L1, 2, semi.L2, 3, traverse_.L1, 3, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, gen.L1, 2, main.L1, 1, main.L2, 1
+g_declare_globals C.0.0, 0, C.0.1, 1, C.0.2, 2, C.0.3, 3, C.1.2, 2, B.le, 2, B.sub, 2, B.mul, 2, B.mod, 2, B.seq, 2, B.puti, 1, B.geti, 1, functorIO, 0, monadIO, 0, print, 0, input, 0, main, 0, foldableList.foldr.L1, 3, take.L1, 2, semi.L1, 2, semi.L2, 3, traverse_.L1, 3, functorIO.map.L1, 3, functorIO.map.L2, 2, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, gen.L1, 2, main.L1, 1, main.L2, 1
 g_declare_main main
 
 g_globstart C.0.0, 0
 g_updcons 0, 0, 1
 g_return
 
+g_globstart C.0.1, 1
+g_updcons 0, 1, 1
+g_return
+
 g_globstart C.0.2, 2
 g_updcons 0, 2, 1
+g_return
+
+g_globstart C.0.3, 3
+g_updcons 0, 3, 1
 g_return
 
 g_globstart C.1.2, 2
@@ -71,10 +79,16 @@ g_input
 g_update 1
 g_return
 
+g_globstart functorIO, 0
+g_pushglobal functorIO.map.L2
+g_updcons 0, 1, 1
+g_return
+
 g_globstart monadIO, 0
 g_pushglobal monadIO.bind.L2
 g_pushglobal monadIO.pure.L2
-g_updcons 0, 2, 1
+g_pushglobal functorIO
+g_updcons 0, 3, 1
 g_return
 
 g_globstart print, 0
@@ -173,7 +187,7 @@ g_mkap 1
 g_push 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -188,6 +202,28 @@ g_push 1
 g_pushglobal semi.L2
 g_updap 2, 4
 g_pop 3
+g_unwind
+
+g_globstart functorIO.map.L1, 3
+g_push 2
+g_push 2
+g_mkap 1
+g_eval
+g_uncons 2
+g_push 1
+g_push 1
+g_push 4
+g_mkap 1
+g_updcons 0, 2, 6
+g_pop 5
+g_return
+
+g_globstart functorIO.map.L2, 2
+g_push 1
+g_push 1
+g_pushglobal functorIO.map.L1
+g_updap 2, 3
+g_pop 2
 g_unwind
 
 g_globstart monadIO.pure.L2, 1

--- a/test/sort_gen.pl
+++ b/test/sort_gen.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 external le_int : Int -> Int -> Bool = "le"
@@ -38,7 +38,9 @@ external mod : Int -> Int -> Int = "mod"
 external seq : forall a b. a -> b -> b = "seq"
 external puti : Int -> Unit = "puti"
 external geti : Unit -> Int = "geti"
-monadIO : Monad IO = .Monad @IO monadIO.pure.L2 monadIO.bind.L2
+functorIO : Functor IO = .Functor @IO functorIO.map.L2
+monadIO : Monad IO =
+  .Monad @IO functorIO monadIO.pure.L2 monadIO.bind.L2
 print : Int -> IO Unit = io.L2 @Int @Unit puti
 input : IO Int = coerce @(_ -> IO) (io.L1 @Unit @Int geti Unit)
 main : IO Unit =
@@ -61,10 +63,17 @@ semi.L1 : forall a m. m a -> Unit -> m a =
 semi.L2 : forall a m. Monad m -> m Unit -> m a -> m a =
   fun @a @m (monad.m : Monad m) (m1 : m Unit) (m2 : m a) ->
     (match monad.m with
-     | .Monad _ bind -> bind) @Unit @a m1 (semi.L1 @a @m m2)
+     | .Monad _ _ bind -> bind) @Unit @a m1 (semi.L1 @a @m m2)
 traverse_.L1 : forall a m. Monad m -> (a -> m Unit) -> a -> m Unit -> m Unit =
   fun @a @m (monad.m : Monad m) (f : a -> m Unit) (x : a) ->
     semi.L2 @Unit @m monad.m (f x)
+functorIO.map.L1 : forall a b. (a -> b) -> IO a -> World -> Pair b World =
+  fun @a @b (f : a -> b) (mx : IO a) (world0 : World) ->
+    match coerce @(IO -> _) mx world0 with
+    | Pair x world1 -> Pair @b @World (f x) world1
+functorIO.map.L2 : forall a b. (a -> b) -> IO a -> IO b =
+  fun @a @b (f : a -> b) (mx : IO a) ->
+    coerce @(_ -> IO) (functorIO.map.L1 @a @b f mx)
 monadIO.pure.L2 : forall a. a -> IO a =
   fun @a (x : a) -> coerce @(_ -> IO) (Pair @a @World x)
 monadIO.bind.L1 : forall a b. IO a -> (a -> IO b) -> World -> Pair b World =

--- a/test/std2/io.pu
+++ b/test/std2/io.pu
@@ -24,6 +24,11 @@ type World = external
 
 type IO a = World -> Pair a World
 
+instance functorIO : Functor IO where
+  map f mx = coerce@(_ -> IO) (fun world0 ->
+    match (coerce @(IO -> _) mx) world0 with
+    | Pair x world1 -> Pair (f x) world1)
+
 instance monadIO : Monad IO where
   pure x = coerce @(_ -> IO) (fun world -> Pair x world)
   bind mx f = coerce @(_ -> IO) (fun world0 ->

--- a/test/std2/monad.pu
+++ b/test/std2/monad.pu
@@ -1,8 +1,9 @@
 -- The monad class and some useful functions for monads
 import std2/basic
+import std2/functor
 import std2/list
 
-class Monad m where
+class (Functor m) <= Monad m where
   pure : a -> m a
   bind : m a -> (a -> m b) -> m b
 

--- a/test/std2/ord.pu
+++ b/test/std2/ord.pu
@@ -1,7 +1,7 @@
 -- Orderings
 import std2/basic
 
-class Ord a where
+class (Eq a) <= Ord a where
   ge : a -> a -> Bool
   gt : a -> a -> Bool
   le : a -> a -> Bool

--- a/test/tsort.asm
+++ b/test/tsort.asm
@@ -1,16 +1,24 @@
-g_declare_globals C.0.0, 0, C.0.2, 2, C.0.4, 4, C.1.2, 2, C.1.3, 3, B.lt, 2, B.le, 2, B.ge, 2, B.gt, 2, B.sub, 2, B.seq, 2, B.puti, 1, B.geti, 1, ordInt, 0, monadIO, 0, print, 0, input, 0, main, 0, foldableList.foldr.L1, 3, foldableList.foldl.L1, 3, replicate.L1, 2, semi.L1, 2, semi.L2, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, traverse_.L1, 3, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, foldableBinTree.foldr.L1, 3, bag_insert.L1, 4, tsort.L1, 2, main.L1, 1, main.L2, 1
+g_declare_globals C.0.0, 0, C.0.1, 1, C.0.2, 2, C.0.3, 3, C.0.5, 5, C.1.2, 2, C.1.3, 3, B.eq, 2, B.lt, 2, B.le, 2, B.ge, 2, B.gt, 2, B.sub, 2, B.seq, 2, B.puti, 1, B.geti, 1, eqInt, 0, ordInt, 0, functorIO, 0, monadIO, 0, print, 0, input, 0, main, 0, foldableList.foldr.L1, 3, foldableList.foldl.L1, 3, replicate.L1, 2, semi.L1, 2, semi.L2, 3, sequence.L1, 3, sequence.L2, 3, sequence.L3, 2, traverse_.L1, 3, functorIO.map.L1, 3, functorIO.map.L2, 2, monadIO.pure.L2, 1, monadIO.bind.L1, 3, monadIO.bind.L2, 2, io.L1, 3, io.L2, 2, foldableBinTree.foldr.L1, 3, bag_insert.L1, 4, tsort.L1, 2, main.L1, 1, main.L2, 1
 g_declare_main main
 
 g_globstart C.0.0, 0
 g_updcons 0, 0, 1
 g_return
 
+g_globstart C.0.1, 1
+g_updcons 0, 1, 1
+g_return
+
 g_globstart C.0.2, 2
 g_updcons 0, 2, 1
 g_return
 
-g_globstart C.0.4, 4
-g_updcons 0, 4, 1
+g_globstart C.0.3, 3
+g_updcons 0, 3, 1
+g_return
+
+g_globstart C.0.5, 5
+g_updcons 0, 5, 1
 g_return
 
 g_globstart C.1.2, 2
@@ -19,6 +27,16 @@ g_return
 
 g_globstart C.1.3, 3
 g_updcons 1, 3, 1
+g_return
+
+g_globstart B.eq, 2
+g_push 1
+g_eval
+g_push 1
+g_eval
+g_eqv
+g_update 3
+g_pop 2
 g_return
 
 g_globstart B.lt, 2
@@ -89,18 +107,30 @@ g_input
 g_update 1
 g_return
 
+g_globstart eqInt, 0
+g_pushglobal B.eq
+g_updcons 0, 1, 1
+g_return
+
 g_globstart ordInt, 0
 g_pushglobal B.lt
 g_pushglobal B.le
 g_pushglobal B.gt
 g_pushglobal B.ge
-g_updcons 0, 4, 1
+g_pushglobal eqInt
+g_updcons 0, 5, 1
+g_return
+
+g_globstart functorIO, 0
+g_pushglobal functorIO.map.L2
+g_updcons 0, 1, 1
 g_return
 
 g_globstart monadIO, 0
 g_pushglobal monadIO.bind.L2
 g_pushglobal monadIO.pure.L2
-g_updcons 0, 2, 1
+g_pushglobal functorIO
+g_updcons 0, 3, 1
 g_return
 
 g_globstart print, 0
@@ -209,7 +239,7 @@ g_mkap 1
 g_push 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -222,7 +252,7 @@ g_push 2
 g_cons 1, 2
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 4
@@ -240,7 +270,7 @@ g_pushglobal sequence.L3
 g_mkap 2
 g_push 2
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 4
@@ -256,7 +286,7 @@ g_pop 1
 g_pushglobal C.0.0
 g_push 1
 g_eval
-g_proj 0
+g_proj 1
 g_push 0
 g_slide 1
 g_updap 1, 3
@@ -271,7 +301,7 @@ g_mkap 2
 g_push 1
 g_push 4
 g_eval
-g_proj 1
+g_proj 2
 g_push 0
 g_slide 1
 g_updap 2, 5
@@ -287,6 +317,28 @@ g_push 1
 g_pushglobal semi.L2
 g_updap 2, 4
 g_pop 3
+g_unwind
+
+g_globstart functorIO.map.L1, 3
+g_push 2
+g_push 2
+g_mkap 1
+g_eval
+g_uncons 2
+g_push 1
+g_push 1
+g_push 4
+g_mkap 1
+g_updcons 0, 2, 6
+g_pop 5
+g_return
+
+g_globstart functorIO.map.L2, 2
+g_push 1
+g_push 1
+g_pushglobal functorIO.map.L1
+g_updap 2, 3
+g_pop 2
 g_unwind
 
 g_globstart monadIO.pure.L2, 1
@@ -384,7 +436,7 @@ g_push 1
 g_push 6
 g_push 6
 g_eval
-g_proj 3
+g_proj 4
 g_push 0
 g_slide 1
 g_mkap 2

--- a/test/wildcard.pl
+++ b/test/wildcard.pl
@@ -14,21 +14,21 @@ data Choice a b =
 data Eq a =
        | .Eq (a -> a -> Bool)
 data Ord a =
-       | .Ord (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
+       | .Ord (Eq a) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool) (a -> a -> Bool)
 data Monoid m =
        | .Monoid m (m -> m -> m)
 data Ring a =
        | .Ring (a -> a) (a -> a -> a) (a -> a -> a) (a -> a -> a)
 data Char
-data Foldable t =
-       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data Functor f =
        | .Functor (forall a b. (a -> b) -> f a -> f b)
+data Foldable t =
+       | .Foldable (forall a b. (a -> b -> b) -> b -> t a -> b) (forall a b. (b -> a -> b) -> b -> t a -> b)
 data List a =
        | Nil
        | Cons a (List a)
 data Monad m =
-       | .Monad (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
+       | .Monad (Functor m) (forall a. a -> m a) (forall a b. m a -> (a -> m b) -> m b)
 data World
 data IO a = World -> Pair a World
 external seq : forall a b. a -> b -> b = "seq"


### PR DESCRIPTION
Currently, there are no super classes at all.

This patch adds a very limited form of super classes. Each type class can have at most one super class. Type class constraints are not simplified during let-generalization, i.e., if a function defined in a let-binding uses `Eq` and `Ord`, than it's inferred type will have the `Eq` and the `Ord` constraint in
its context. However, if a top level function uses `Eq` and `Ord` but has only `Ord` in its context, then the superclass relationship between `Eq` and `Ord` is used to derive the `Eq` instance from the `Ord` instance.