### PR TITLE
Prepare let bindings for dictionaries

### DIFF
--- a/src/Pukeko/BackEnd/PeepHole.hs
+++ b/src/Pukeko/BackEnd/PeepHole.hs
@@ -27,6 +27,7 @@ opt :: [Inst] -> Maybe [Inst]
 opt code0 = case code0 of
  UNWIND:JUMP _:code      -> Just $ UNWIND:code
  POP 0:code              -> Just code
+ SLIDE k:SLIDE l:code    -> Just $ SLIDE (k+l):code
  MKAP 0:code             -> Just code
  MKAP k:MKAP l:code      -> Just $ MKAP (k+l):code
  MKAP a:UPDATE k:code    -> Just $ UPDAP a k:code

--- a/src/Pukeko/FrontEnd/ClassEliminator.hs
+++ b/src/Pukeko/FrontEnd/ClassEliminator.hs
@@ -170,7 +170,7 @@ elimExpr = \case
   ETyAbs vs0 e0 -> ETyAbs vs0 <$> elimExpr e0
   EDxAbs (x, c) e0 -> ETmAbs (x, mkTDict c) <$> elimExpr e0
   EAbs{} -> impossible
-  ELet m ds0 e0 -> ELet m <$> traverse (b2bound elimExpr) ds0 <*> elimExpr e0
+  ELet b e0 -> ELet <$> bind2expr elimExpr b <*> elimExpr e0
   EMat t e0 as -> EMat t <$> elimExpr e0 <*> traverse (altn2expr elimExpr) as
   ECast coe e0 -> ECast coe <$> elimExpr e0
   ETyAnn t0 e0 -> ETyAnn t0 <$> elimExpr e0

--- a/src/Pukeko/FrontEnd/PatternMatcher.hs
+++ b/src/Pukeko/FrontEnd/PatternMatcher.hs
@@ -43,7 +43,7 @@ pmExpr = \case
   EAbs (TmPar x) e -> ETmAbs x <$> pmExpr e
   EAbs (TyPar v) e -> ETyAbs v <$> pmExpr e
   EAbs (DxPar c) e -> EDxAbs c <$> pmExpr e
-  ELet m ds t      -> ELet m <$> traverse (b2bound pmExpr) ds <*> pmExpr t
+  ELet b e -> ELet <$> bind2expr pmExpr b <*> pmExpr e
   EMat t0 e0 as0     -> LS.withNonEmpty as0 $ \as1 -> do
       e1 <- pmExpr e0
       pmMatch (mkRowMatch1 e1 t0 as1)

--- a/test/backend/examples/monad_io.golden
+++ b/test/backend/examples/monad_io.golden
@@ -111,8 +111,7 @@ g_push 0
 g_push 3
 g_pushglobal monadIO.bind.L1
 g_mkap 2
-g_slide 1
-g_slide 2
+g_slide 3
 g_push 1
 g_eval
 g_jumpcase .0, .1

--- a/test/backend/examples/primes.golden
+++ b/test/backend/examples/primes.golden
@@ -164,8 +164,7 @@ g_updap 2, 1
 g_push 3
 g_push 1
 g_mkap 1
-g_slide 1
-g_slide 1
+g_slide 2
 g_pushglobal sieve
 g_mkap 1
 g_push 1
@@ -196,8 +195,7 @@ g_mkap 2
 g_slide 1
 g_update 1
 g_push 0
-g_slide 1
-g_slide 1
+g_slide 2
 g_pushint 5
 g_cons 1, 2
 g_pushglobal psums

--- a/test/backend/examples/rmq_gen.golden
+++ b/test/backend/examples/rmq_gen.golden
@@ -155,9 +155,7 @@ g_pushglobal main.L2
 g_push 1
 g_pushglobal monadIO.bind.L1
 g_mkap 2
-g_slide 1
-g_slide 1
-g_slide 2
+g_slide 4
 g_push 0
 g_pushglobal semi.L1
 g_mkap 1
@@ -165,9 +163,7 @@ g_push 0
 g_push 3
 g_pushglobal monadIO.bind.L1
 g_mkap 2
-g_slide 1
-g_slide 2
-g_slide 2
+g_slide 5
 g_push 0
 g_pushglobal semi.L1
 g_mkap 1
@@ -175,8 +171,7 @@ g_push 0
 g_push 3
 g_pushglobal monadIO.bind.L1
 g_mkap 2
-g_slide 1
-g_slide 2
+g_slide 3
 g_push 0
 g_pushglobal semi.L1
 g_mkap 1

--- a/test/middleend/examples/fix.golden
+++ b/test/middleend/examples/fix.golden
@@ -181,9 +181,11 @@ main.L2 :: List Int -> IO Unit =
   \(xs :: List Int) ->
     foldableList.foldr.L1 @Int @(IO Unit) (traverse_.L1 @Int @IO monadIO print) (coerce @(_ -> IO) (Pair @Unit @World Unit)) (let f :: Fix (ListF Int) -> List Int =
                                                                                                                                     cata.L1 @(List Int) @(ListF Int) (.Functor @(ListF Int) (functorListF.map.L1 @Int)) (toList.L1 @Int)
-                                                                                                                              and g :: Fix2 ListF Int -> Fix (ListF Int) =
+                                                                                                                              in
+                                                                                                                              let g :: Fix2 ListF Int -> Fix (ListF Int) =
                                                                                                                                     mono @Int @ListF bifunctorListF
-                                                                                                                              and x :: Fix2 ListF Int =
+                                                                                                                              in
+                                                                                                                              let x :: Fix2 ListF Int =
                                                                                                                                     let dict :: Functor (Fix2 ListF) =
                                                                                                                                           functorFox2 @ListF bifunctorListF
                                                                                                                                     in
@@ -191,7 +193,8 @@ main.L2 :: List Int -> IO Unit =
                                                                                                                                      | .Functor map ->
                                                                                                                                        map) @Int @Int main.L1 (let f :: Fix (ListF Int) -> Fix2 ListF Int =
                                                                                                                                                                      poly @Int @ListF bifunctorListF
-                                                                                                                                                               and g :: List Int -> Fix (ListF Int) =
+                                                                                                                                                               in
+                                                                                                                                                               let g :: List Int -> Fix (ListF Int) =
                                                                                                                                                                      ana.L1 @(List Int) @(ListF Int) (.Functor @(ListF Int) (functorListF.map.L1 @Int)) (fromList.L1 @Int)
                                                                                                                                                                in
                                                                                                                                                                f (g xs))

--- a/test/middleend/examples/monad_io.golden
+++ b/test/middleend/examples/monad_io.golden
@@ -44,11 +44,10 @@ print :: Int -> IO Unit = io.L2 @Int @Unit puti
 input :: IO Int = coerce @(_ -> IO) (io.L1 @Unit @Int geti Unit)
 count_down :: Int -> IO Unit =
   \(k :: Int) ->
-    let p :: Bool = ge_int k 0
-    and m :: IO Unit =
-          let m1 :: IO Unit = print k
-          and m2 :: IO Unit = count_down (sub_int k 1)
-          in
+    let p :: Bool = ge_int k 0 in
+    let m :: IO Unit =
+          let m1 :: IO Unit = print k in
+          let m2 :: IO Unit = count_down (sub_int k 1) in
           let f :: Unit -> IO Unit = semi.L1 @Unit @IO m2 in
           coerce @(_ -> IO) (monadIO.bind.L1 @Unit @Unit m1 f)
     in
@@ -84,8 +83,8 @@ io.L2 :: forall a b. (a -> b) -> a -> IO b =
     coerce @(_ -> IO) (io.L1 @a @b f x)
 repeat.L1 :: forall m. Monad m -> Int -> m Unit -> m Unit =
   \@m (monad.m :: Monad m) (k :: Int) (m :: m Unit) ->
-    let p :: Bool = gt_int k 0
-    and m :: m Unit =
+    let p :: Bool = gt_int k 0 in
+    let m :: m Unit =
           let m2 :: m Unit = repeat.L1 @m monad.m (sub_int k 1) m in
           (case monad.m of
            | .Monad _ _ bind -> bind) @Unit @Unit m (semi.L1 @Unit @m m2)

--- a/test/middleend/examples/queens.golden
+++ b/test/middleend/examples/queens.golden
@@ -52,8 +52,8 @@ solve_aux :: List (List Int) -> List (List Int) =
     | Cons ks kss ->
       let monoid.m :: Monoid (List (List Int)) =
             .Monoid @(List (List Int)) (monoidList.empty @(List Int)) (monoidList.append.L1 @(List Int))
-      and f :: Int -> List (List Int) = solve_aux.L2 kss
       in
+      let f :: Int -> List (List Int) = solve_aux.L2 kss in
       foldableList.foldr.L1 @Int @(List (List Int)) (foldMap.L1 @Int @(List (List Int)) monoid.m f) (case monoid.m of
                                                                                                      | .Monoid empty _ ->
                                                                                                        empty) ks

--- a/test/middleend/examples/rev.golden
+++ b/test/middleend/examples/rev.golden
@@ -48,8 +48,8 @@ read :: List Char -> IO (List Char) =
     let f :: Option Char -> IO (List Char) = read.L1 cs in
     coerce @(_ -> IO) (monadIO.bind.L1 @(Option Char) @(List Char) getChar f)
 main :: IO Unit =
-  let mx :: IO (List Char) = read (Nil @Char)
-  and f :: List Char -> IO Unit =
+  let mx :: IO (List Char) = read (Nil @Char) in
+  let f :: List Char -> IO Unit =
         foldableList.foldr.L1 @Char @(IO Unit) (traverse_.L1 @Char @IO monadIO putChar) (coerce @(_ -> IO) (Pair @Unit @World Unit))
   in
   coerce @(_ -> IO) (monadIO.bind.L1 @(List Char) @Unit mx f)

--- a/test/middleend/examples/rmq.golden
+++ b/test/middleend/examples/rmq.golden
@@ -144,16 +144,14 @@ query.L1 :: forall a. a -> (a -> a -> a) -> Int -> Int -> (RmqTree a -> a) -> Rm
     case t of
     | RmqEmpty -> one
     | RmqNode t_lo t_hi value left right ->
-      case let x :: Bool = lt_int q_hi t_lo
-           and y :: Bool = gt_int q_lo t_hi
-           in
+      case let x :: Bool = lt_int q_hi t_lo in
+           let y :: Bool = gt_int q_lo t_hi in
            case x of
            | False -> y
            | True -> True of
       | False ->
-        case let x :: Bool = le_int q_lo t_lo
-             and y :: Bool = le_int t_hi q_hi
-             in
+        case let x :: Bool = le_int q_lo t_lo in
+             let y :: Bool = le_int t_hi q_hi in
              case x of
              | False -> False
              | True -> y of
@@ -200,8 +198,8 @@ main.L5 :: Int -> Int -> IO Unit =
   \(n :: Int) (m :: Int) ->
     let mx :: IO (List Int) =
           sequence.L3 @Int @IO monadIO (replicate.L1 @(IO Int) n input)
-    and f :: List Int -> IO Unit = main.L4 m
     in
+    let f :: List Int -> IO Unit = main.L4 m in
     coerce @(_ -> IO) (monadIO.bind.L1 @(List Int) @Unit mx f)
 main.L6 :: Int -> IO Unit =
   \(n :: Int) ->

--- a/test/middleend/examples/rmq_gen.golden
+++ b/test/middleend/examples/rmq_gen.golden
@@ -44,15 +44,16 @@ monadIO :: Monad IO =
 print :: Int -> IO Unit = io.L2 @Int @Unit puti
 random :: List Int = gen.L1 @Int random.L1 1
 main :: IO Unit =
-  let m1 :: IO Unit = print 400000
-  and m2 :: IO Unit =
-        let m1 :: IO Unit = print 100000
-        and m2 :: IO Unit =
+  let m1 :: IO Unit = print 400000 in
+  let m2 :: IO Unit =
+        let m1 :: IO Unit = print 100000 in
+        let m2 :: IO Unit =
               case split_at.L1 @Int 400000 random of
               | Pair xs random ->
                 let m1 :: IO Unit =
                       foldableList.foldr.L1 @Int @(IO Unit) (traverse_.L1 @Int @IO monadIO print) (coerce @(_ -> IO) (Pair @Unit @World Unit)) xs
-                and m2 :: IO Unit =
+                in
+                let m2 :: IO Unit =
                       case split_at.L1 @Int 100000 random of
                       | Pair ys random ->
                         let zs :: List Int = take.L1 @Int 100000 random in
@@ -161,15 +162,13 @@ main.L1 :: Int -> Int -> Int -> IO Unit =
     let z :: Int = mod z n in
     case lt_int y z of
     | False ->
-      let m1 :: IO Unit = print z
-      and m2 :: IO Unit = print y
-      in
+      let m1 :: IO Unit = print z in
+      let m2 :: IO Unit = print y in
       let f :: Unit -> IO Unit = semi.L1 @Unit @IO m2 in
       coerce @(_ -> IO) (monadIO.bind.L1 @Unit @Unit m1 f)
     | True ->
-      let m1 :: IO Unit = print y
-      and m2 :: IO Unit = print z
-      in
+      let m1 :: IO Unit = print y in
+      let m2 :: IO Unit = print z in
       let f :: Unit -> IO Unit = semi.L1 @Unit @IO m2 in
       coerce @(_ -> IO) (monadIO.bind.L1 @Unit @Unit m1 f)
 main.L2 :: List Unit -> IO Unit =

--- a/test/middleend/examples/sort_gen.golden
+++ b/test/middleend/examples/sort_gen.golden
@@ -96,8 +96,8 @@ main.L1 :: Int -> Int =
   \(x :: Int) -> mod (mul_int 91 x) 1000000007
 main.L2 :: Int -> IO Unit =
   \(n :: Int) ->
-    let m1 :: IO Unit = print n
-    and m2 :: IO Unit =
+    let m1 :: IO Unit = print n in
+    let m2 :: IO Unit =
           foldableList.foldr.L1 @Int @(IO Unit) (traverse_.L1 @Int @IO monadIO print) (coerce @(_ -> IO) (Pair @Unit @World Unit)) (take.L1 @Int n (gen.L1 @Int main.L1 1))
     in
     let f :: Unit -> IO Unit = semi.L1 @Unit @IO m2 in

--- a/test/middleend/examples/tsort.golden
+++ b/test/middleend/examples/tsort.golden
@@ -144,9 +144,11 @@ main.L1 :: List Int -> IO Unit =
   \(xs :: List Int) ->
     foldableList.foldr.L1 @Int @(IO Unit) (traverse_.L1 @Int @IO monadIO print) (coerce @(_ -> IO) (Pair @Unit @World Unit)) (let f :: Int -> List Int -> List Int =
                                                                                                                                     Cons @Int
-                                                                                                                              and y0 :: List Int =
+                                                                                                                              in
+                                                                                                                              let y0 :: List Int =
                                                                                                                                     Nil @Int
-                                                                                                                              and bag :: Bag Int =
+                                                                                                                              in
+                                                                                                                              let bag :: Bag Int =
                                                                                                                                     foldableList.foldl.L1 @Int @(Bag Int) tsort.L1 (coerce @(_ -> Bag) (Leaf @Int)) xs
                                                                                                                               in
                                                                                                                               foldableBinTree.foldr.L1 @Int @(List Int) f y0 (coerce @(Bag -> _) bag))

--- a/test/middleend/examples/wildcard.golden
+++ b/test/middleend/examples/wildcard.golden
@@ -57,7 +57,8 @@ main.L1 :: Int -> Int -> IO Unit =
     let m1 :: IO Unit =
           print (case p of
                  | Pair x _ -> x)
-    and m2 :: IO Unit =
+    in
+    let m2 :: IO Unit =
           print (case p of
                  | Pair _ y -> y)
     in


### PR DESCRIPTION
This refactoring changes the `ELet` node in the AST such that it represents
either a single non-recursive binding or a group of recursive bindings.

To avoid a regression, we also need to improve the peephole optimizer.