### PR TITLE
Remove `let ... and ... in ...` from `NoLambda`

### DIFF
--- a/src/Pukeko/AST/NoLambda.hs
+++ b/src/Pukeko/AST/NoLambda.hs
@@ -27,7 +27,8 @@ data Expr
   | Pack    {_tag, _arity :: Int}
   | Num     {_int :: Int}
   | Ap      {_fun :: Expr, _args :: [Expr]}
-  | Let     {_isrec :: Bool, _defns :: [Defn], _body :: Expr}
+  | Let     {_defn :: Defn, _body :: Expr}
+  | LetRec  {_defns :: [Defn], _body :: Expr}
   | Match   {_expr  :: Expr, _altns :: [Altn]}
   deriving (Show)
 
@@ -79,16 +80,22 @@ instance PrettyPrec Expr where
       Ap{ _fun, _args } ->
         maybeParens (prec > 0) $ hsep $
           prettyPrec 1 _fun : map (prettyPrec 1) _args
-      Let{ _isrec, _defns, _body } ->
+      Let{_defn, _body} ->
+        vcat
+        [ sep
+          [ "let" <+> pretty _defn
+          , "in"
+          ]
+        , pretty _body
+        ]
+      LetRec{_defns, _body} ->
         case _defns of
           [] -> impossible  -- maintained invariant
           defn0:defns ->
-            let let_ | _isrec    = "let rec"
-                     | otherwise = "let"
-            in  vcat
+                vcat
                 [ sep
                   [ vcat $
-                    (let_ <+> pretty defn0) :
+                    ("let rec" <+> pretty defn0) :
                     map (\defn -> "and" <+> pretty defn) defns
                   , "in"
                   ]

--- a/src/Pukeko/BackEnd/Info.hs
+++ b/src/Pukeko/BackEnd/Info.hs
@@ -40,7 +40,8 @@ infoExpr expr = case expr of
   Pack{_tag, _arity}   -> constructor _tag _arity
   Num{}                -> mempty
   Ap{_fun, _args}      -> foldMap infoExpr (_fun : _args)
-  Let{_defns, _body}   -> foldMap infoDefn _defns <> infoExpr _body
+  Let{_defn, _body} -> infoDefn _defn <> infoExpr _body
+  LetRec{_defns, _body} -> foldMap infoDefn _defns <> infoExpr _body
   Match{_expr, _altns} -> infoExpr _expr <> foldMap infoAltn _altns
 
 infoDefn :: Defn -> Info

--- a/src/Pukeko/MiddleEnd/TypeEraser.hs
+++ b/src/Pukeko/MiddleEnd/TypeEraser.hs
@@ -62,9 +62,9 @@ ccExpr = \case
   e0@(In.EApp _ In.TmArg{})
     | (e1, as) <- In.unwindl In._ETmApp e0 -> Ap <$> ccExpr e1 <*> traverse ccExpr as
   In.ELet (In.TmNonRec b e0) e1 ->
-    Let False <$> ((:[]) <$> (MkDefn (bindName b) <$> ccExpr e0)) <*> ccExpr e1
+    Let <$> (MkDefn (bindName b) <$> ccExpr e0) <*> ccExpr e1
   In.ELet (In.TmRec bs) e1 ->
-    Let True
+    LetRec
     <$> traverse (\(b, e0) -> MkDefn (bindName b) <$> ccExpr e0) (toList bs)
     <*> ccExpr e1
   In.EMat _ e cs -> Match <$> ccExpr e <*> traverse ccAltn (toList cs)


### PR DESCRIPTION
The compiler frontend has stopped supporting `let ... and ... in ...` a
while ago. To simplify the future use of de Bruijn indices in the code
generator, we remove it from `NoLambda` as well.