### PR TITLE
Upgrade stackage + maintenance

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -7,7 +7,6 @@
 
 
 # Warnings currently triggered by your code
-- ignore: {name: "Reduce duplication", within: Pukeko.FrontEnd.Renamer}
 - ignore: {name: "Use camelCase", within: RunExamples}
 
 
@@ -18,9 +17,18 @@
 
 # Control which extensions/flags/modules/functions can be used
 #
-# - extensions:
-#   - default: false # all extension are banned by default
-#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+- extensions:
+  - default: false # all extension are banned by default
+  - name:
+    - AllowAmbiguousTypes
+    - BangPatterns
+    - DefaultSignatures
+    - GADTs
+    - MultiParamTypeClasses
+    - PatternSynonyms
+    - PolyKinds
+    - TemplateHaskell
+    - UndecidableInstances
 #   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
 #
 # - flags:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 # Install hlint
-- stack -j1 --no-terminal --install-ghc build # hlint
+- stack -j1 --no-terminal --install-ghc build hlint
 
 install:
 # Build dependencies
@@ -39,6 +39,6 @@ install:
 
 script:
 # Run hlint
-# - stack exec hlint -- --git
+- stack exec hlint -- --git
 # Build the package, its tests, and its docs and run the tests
 - stack -j1 --no-terminal test --pedantic :golden

--- a/package.yaml
+++ b/package.yaml
@@ -1,10 +1,10 @@
 name: pukeko
-version: 0.0.1
+version: 0.0.2
 synopsis: "A toy compiler based on SPJ's book \"The Implementation of Functional Programming Languages\""
 description: Please see README.md
 category: Compilers/Interpreters
 author: Martin Huschenbett <martin.huschenbett@posteo.me>
-copyright: 2017 Martin Huschenbett
+copyright: 2017-2018 Martin Huschenbett
 license: BSD3
 github: hurryabit/pukeko
 

--- a/src/Pukeko/MiddleEnd.hs
+++ b/src/Pukeko/MiddleEnd.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE RankNTypes #-}
 module Pukeko.MiddleEnd
   ( Module
   , Optimization (..)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-10-19
+resolver: nightly-2018-11-11
 
 packages:
 - '.'

--- a/test/RunExamples.hs
+++ b/test/RunExamples.hs
@@ -3,41 +3,23 @@ module RunExamples where
 
 import Pukeko.Prelude hiding (assert, run)
 
-import Data.IORef
 import System.Directory (setCurrentDirectory)
 import System.Exit (ExitCode (..))
 import System.FilePath
 import System.Process (readProcess, readProcessWithExitCode)
-import System.IO.Unsafe
 import Test.Hspec
-import Test.Hspec.QuickCheck
 import Test.QuickCheck
 import Test.QuickCheck.Monadic
-
-data Mode = Native | Ruceki
-
-modeRef :: IORef Mode
-modeRef = unsafePerformIO $ newIORef Native
-{-# NOINLINE modeRef #-}
-
-getMode :: IO Mode
-getMode = readIORef modeRef
 
 format :: [Int] -> String
 format = unlines . map show
 
 runProg :: FilePath -> String -> IO (ExitCode, String)
 runProg prog input = do
-  mode <- getMode
-  let (cmd, args) = case mode of
-        Native -> ("." </> prog, [])
-        Ruceki -> ("ruceki", [prog <.> "pub"])
-  (exitCode, stdout, _) <- readProcessWithExitCode cmd args input
+  (exitCode, stdout, _) <- readProcessWithExitCode ("." </> prog) [] input
   return (exitCode, stdout)
 
-build prog = getMode >>= \case
-  Native -> void (readProcess "make" [prog] "")
-  Ruceki -> void (readProcess "make" [prog <.> "pub"] "")
+build prog = void (readProcess "make" [prog] "")
 
 specifyProg name = beforeAll_ (build name) . specify name
 
@@ -130,33 +112,20 @@ prop_rmq_correct prog = monadicIO $ do
 
 main :: IO ()
 main = hspec $ beforeAll_ (setCurrentDirectory "examples") $ do
-  describe "native" $ do
-    describe "test basics" $ do
+    describe "basics" $ do
       testText    "hello" "" "Hello World!\n"
       testText    "rev" "abc" "cba"
       testNumeric "monad_io" [3, 2]  (concat $ replicate 3 [2, 1, 0])
       testNumeric "wildcard" [7, 13] [7, 13]
       testNumeric "fix"      (10:[1 .. 10]) [2, 4 .. 20]
-    describe "test sorting" $ mapM_ testSort
+    describe "sorting" $ mapM_ testSort
       [ "isort"
       , "qsort"
       , "tsort"
       ]
-    describe "test number theory/combinatorics" $ do
+    describe "number theory/combinatorics" $ do
       testFunction "fibs"    1000 spec_fibs
       testFunction "catalan"  100 spec_catalan
       testNumeric  "queens"   [8] [92]
       testFunction "primes"   100 spec_primes
       specifyProg "rmq" (prop_rmq_correct "rmq")
-  beforeAll_ (writeIORef modeRef Ruceki) $ describe "interpreted" $ do
-    describe "test basics" $ do
-      testText    "hello" "" "Hello World!\n"
-      testText    "rev" "abc" "cba"
-      testNumeric "monad_io" [3, 2]  (concat $ replicate 3 [2, 1, 0])
-      testNumeric "wildcard" [7, 13] [7, 13]
-    describe "test sorting" $ modifyMaxSuccess (const 10) $ mapM_ testSort
-      [ "isort"
-      , "qsort"
-      ]
-    describe "test number theory/combinatorics" $ do
-      testNumeric  "queens"   [8] [92]

--- a/test/frontend/pattern-matcher/too-simple-term-con.golden
+++ b/test/frontend/pattern-matcher/too-simple-term-con.golden
@@ -1,4 +1,7 @@
 test/frontend/pattern-matcher/too-simple-term-con.pu:5:3:
+  |
+5 |   y -> y
+  |   ^
 unexpected 'y'
 expecting data constructor
 

--- a/test/frontend/pattern-matcher/too-simple-var.golden
+++ b/test/frontend/pattern-matcher/too-simple-var.golden
@@ -1,4 +1,7 @@
 test/frontend/pattern-matcher/too-simple-var.pu:5:5:
+  |
+5 |     y -> y
+  |     ^
 unexpected 'y'
 expecting data constructor
 


### PR DESCRIPTION
- upgrade stackage version to nightly-2018-11-11
- finally change version number to 0.0.2
- update copyright
- adapt to megaparsec 7.0
- bring hlint back with tighter rules regarding extensions
- remove ruceki tests (ruceki has its own tests now)